### PR TITLE
feat(gatsby-theme-emma): missing projects do not break site anymore

### DIFF
--- a/themes/gatsby-theme-emma/README.md
+++ b/themes/gatsby-theme-emma/README.md
@@ -66,8 +66,6 @@ gatsby new emma LekoArts/gatsby-starter-portfolio-emma
 | `pagesPath`    | `content/pages`    | Location of additional pages (optional)                                                                   |
 | `mdx`          | `true`             | Configure `gatsby-plugin-mdx` (if your website already is using the plugin pass `false` to turn this off) |
 
-The usage of `content/projects` is mandatory. Have a look at the [example](https://github.com/LekoArts/gatsby-themes/tree/master/examples/emma) on how to create entries.
-
 The usage of `content/pages` is optional. If no page/MDX file is found the navigation will be hidden.
 
 #### Example usage

--- a/themes/gatsby-theme-emma/gatsby-node.js
+++ b/themes/gatsby-theme-emma/gatsby-node.js
@@ -42,15 +42,15 @@ exports.sourceNodes = ({ actions, schema }) => {
     schema.buildObjectType({
       name: `Project`,
       fields: {
-        slug: { type: `String!` },
-        title: { type: `String!` },
-        client: { type: `String!` },
-        service: { type: `String!` },
-        color: { type: `String!` },
-        date: { type: `Date!`, extensions: { dateformat: {} } },
-        cover: { type: `File!`, extensions: { fileByRelativePath: {} } },
+        slug: { type: `String` },
+        title: { type: `String` },
+        client: { type: `String` },
+        service: { type: `String` },
+        color: { type: `String` },
+        date: { type: `Date`, extensions: { dateformat: {} } },
+        cover: { type: `File`, extensions: { fileByRelativePath: {} } },
         excerpt: {
-          type: `String!`,
+          type: `String`,
           args: {
             pruneLength: {
               type: `Int`,
@@ -60,7 +60,7 @@ exports.sourceNodes = ({ actions, schema }) => {
           resolve: mdxResolverPassthrough(`excerpt`),
         },
         body: {
-          type: `String!`,
+          type: `String`,
           resolve: mdxResolverPassthrough(`body`),
         },
       },

--- a/themes/gatsby-theme-emma/src/templates/projects.tsx
+++ b/themes/gatsby-theme-emma/src/templates/projects.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { jsx } from "theme-ui"
+import { jsx, Container, Styled } from "theme-ui"
 import { useTrail } from "react-spring"
 import { graphql } from "gatsby"
 import Layout from "../components/layout"
@@ -30,6 +30,40 @@ const Projects = ({
     from: { height: `0%` },
     to: { height: `100%` },
   })
+
+  if (nodes.length === 0) {
+    return (
+      <Layout>
+        <Container>
+          <Styled.p>
+            Hi!{` `}
+            <span role="img" aria-label="Wave emoji">
+              👋
+            </span>
+            {` `}
+            <br />
+            Thanks for using <b>@lekoarts/gatsby-theme-emma</b>. You currently don't have any content in your{` `}
+            <i>projects</i> folder - that's why this page displays a placeholder text. Head over to the{` `}
+            <Styled.a href="https://github.com/LekoArts/gatsby-themes/tree/master/themes/gatsby-theme-emma">
+              README
+            </Styled.a>
+            {` `}
+            to learn how to setup them.
+          </Styled.p>
+          <Styled.p>
+            <b>TL;DR:</b> <br />
+            The starter automatically created the folder <code>content/projects</code>. Go into this folder, create a
+            new folder called <code>example</code> and create an <code>index.mdx</code> file there and place an image.
+            Edit the frontmatter like described in the{` `}
+            <Styled.a href="https://github.com/LekoArts/gatsby-themes/tree/master/themes/gatsby-theme-emma">
+              README
+            </Styled.a>
+            .
+          </Styled.p>
+        </Container>
+      </Layout>
+    )
+  }
 
   return (
     <Layout


### PR DESCRIPTION
Previously I mentioned in the README that `projects` are mandatory for the emma theme as otherwise the query would break. Since https://github.com/gatsbyjs/gatsby/pull/16109 fixed this bug, I removed the note and added a (hopefully) helpful placeholder text when someone's project doesn't have content in the `projects` folder.