### PR TITLE
feat: Add GitHub action "Publish Starters"

### DIFF
--- a/.github/workflows/publish-starters.yml
+++ b/.github/workflows/publish-starters.yml
@@ -1,0 +1,20 @@
+name: Publish Starters
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - examples/*
+      - themes/*
+jobs:
+  master:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@latest
+      - name: publish:starters
+        uses: johno/actions-push-subdirectories@master
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: examples LekoArts .starter-name


### PR DESCRIPTION
Publish the examples from this monorepo as starters to their respective starter repositories. Based on https://johno.com/publishing-gatsby-starters-from-monorepo