### PR TITLE
fix(gatsby-theme-emma): Use SDL for schema customizations

### DIFF
--- a/themes/gatsby-theme-emma-core/src/templates/project-query.tsx
+++ b/themes/gatsby-theme-emma-core/src/templates/project-query.tsx
@@ -4,8 +4,8 @@ import ProjectComponent from "../components/project"
 export default ProjectComponent
 
 export const query = graphql`
-  query($id: String!) {
-    project(id: { eq: $id }) {
+  query($slug: String!) {
+    project(slug: { eq: $slug }) {
       body
       excerpt
       client


### PR DESCRIPTION
This also fixes the bug/workaround that previously the projects were filtered by `id`, not `slug`. Also the SDL syntax is so much more readable. Thanks to Stefan! https://github.com/gatsbyjs/gatsby/issues/16890