### PR TITLE
fix(gatsby-theme-minimal-blog): Revert lazy loading

### DIFF
--- a/themes/gatsby-theme-minimal-blog/src/components/code.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/code.tsx
@@ -1,8 +1,9 @@
 /* eslint react/destructuring-assignment: 0 */
 import React from "react"
-import loadable from "@loadable/component"
+import Highlight, { defaultProps, Language } from "prism-react-renderer"
+import theme from "prism-react-renderer/themes/nightOwl"
+import { LiveProvider, LiveEditor, LiveError, LivePreview } from "react-live"
 import useSiteMetadata from "../hooks/use-site-metadata"
-import { HighlightInnerProps, Language } from "../types"
 
 type CodeProps = {
   codeString: string
@@ -11,27 +12,6 @@ type CodeProps = {
   metastring?: string
   [key: string]: any
 }
-
-const LazyHighlight = loadable(async () => {
-  const Module = await import(`prism-react-renderer`)
-  const Highlight = Module.default
-  const { defaultProps } = Module
-  return (props: any) => <Highlight {...defaultProps} {...props} />
-})
-
-const LazyLiveProvider = loadable(async () => {
-  const Module = await import(`react-live`)
-  const { LiveProvider, LiveEditor, LiveError, LivePreview } = Module
-  return (props: any) => (
-    <LiveProvider {...props}>
-      <LiveEditor data-name="live-editor" />
-      <LiveError />
-      <LivePreview data-name="live-preview" />
-    </LiveProvider>
-  )
-})
-
-const theme = loadable(() => import(`prism-react-renderer/themes/nightOwl`))
 
 function getParams(className = ``) {
   const [lang = ``, params = ``] = className.split(`:`)
@@ -87,11 +67,17 @@ const Code = ({
   const hasLineNumbers = !noLineNumbers && language !== `noLineNumbers` && showLineNumbers
 
   if (props[`react-live`]) {
-    return <LazyLiveProvider code={codeString} noInline theme={theme} />
+    return (
+      <LiveProvider code={codeString} noInline theme={theme}>
+        <LiveEditor data-name="live-editor" />
+        <LiveError />
+        <LivePreview data-name="live-preview" />
+      </LiveProvider>
+    )
   }
   return (
-    <LazyHighlight code={codeString} language={language} theme={theme}>
-      {({ className, style, tokens, getLineProps, getTokenProps }: HighlightInnerProps) => (
+    <Highlight {...defaultProps} code={codeString} language={language} theme={theme}>
+      {({ className, style, tokens, getLineProps, getTokenProps }) => (
         <React.Fragment>
           {title && (
             <div className="code-title">
@@ -120,7 +106,7 @@ const Code = ({
           </div>
         </React.Fragment>
       )}
-    </LazyHighlight>
+    </Highlight>
   )
 }
 


### PR DESCRIPTION
Fixes #168

Partially reverts #167 

---

Seems like the Cypress checks didn't catch this error. In a follow-up PR a test will be added and the correct lazy loading behavior is implemented. Need to check what's the culprit there.