### PR TITLE
fix(gatsby-theme-minimal-blog): Re-Add lazy loading

### DIFF
--- a/themes/gatsby-theme-minimal-blog/src/components/code.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/code.tsx
@@ -1,9 +1,9 @@
 /* eslint react/destructuring-assignment: 0 */
 import React from "react"
-import Highlight, { defaultProps, Language } from "prism-react-renderer"
+import loadable from "@loadable/component"
 import theme from "prism-react-renderer/themes/nightOwl"
-import { LiveProvider, LiveEditor, LiveError, LivePreview } from "react-live"
 import useSiteMetadata from "../hooks/use-site-metadata"
+import { HighlightInnerProps, Language } from "../types"
 
 type CodeProps = {
   codeString: string
@@ -12,6 +12,25 @@ type CodeProps = {
   metastring?: string
   [key: string]: any
 }
+
+const LazyHighlight = loadable(async () => {
+  const Module = await import(`prism-react-renderer`)
+  const Highlight = Module.default
+  const { defaultProps } = Module
+  return (props: any) => <Highlight {...defaultProps} {...props} />
+})
+
+const LazyLiveProvider = loadable(async () => {
+  const Module = await import(`react-live`)
+  const { LiveProvider, LiveEditor, LiveError, LivePreview } = Module
+  return (props: any) => (
+    <LiveProvider {...props}>
+      <LiveEditor data-name="live-editor" />
+      <LiveError />
+      <LivePreview data-name="live-preview" />
+    </LiveProvider>
+  )
+})
 
 function getParams(className = ``) {
   const [lang = ``, params = ``] = className.split(`:`)
@@ -67,17 +86,11 @@ const Code = ({
   const hasLineNumbers = !noLineNumbers && language !== `noLineNumbers` && showLineNumbers
 
   if (props[`react-live`]) {
-    return (
-      <LiveProvider code={codeString} noInline theme={theme}>
-        <LiveEditor data-name="live-editor" />
-        <LiveError />
-        <LivePreview data-name="live-preview" />
-      </LiveProvider>
-    )
+    return <LazyLiveProvider code={codeString} noInline theme={theme} />
   }
   return (
-    <Highlight {...defaultProps} code={codeString} language={language} theme={theme}>
-      {({ className, style, tokens, getLineProps, getTokenProps }) => (
+    <LazyHighlight code={codeString} language={language} theme={theme}>
+      {({ className, style, tokens, getLineProps, getTokenProps }: HighlightInnerProps) => (
         <React.Fragment>
           {title && (
             <div className="code-title">
@@ -106,7 +119,7 @@ const Code = ({
           </div>
         </React.Fragment>
       )}
-    </Highlight>
+    </LazyHighlight>
   )
 }
 


### PR DESCRIPTION
Follow-up to #168 and #169 

This time the `theme` doesn't get lazy-loaded and manual tests show the site working with lazy loading + of course the bundle is smaller.