### PR TITLE
feat(gatsby-theme-emma): Improve shadow-ability of project template

### DIFF
--- a/themes/gatsby-theme-emma/src/components/project-info-item.tsx
+++ b/themes/gatsby-theme-emma/src/components/project-info-item.tsx
@@ -1,0 +1,33 @@
+/** @jsx jsx */
+import { Flex, jsx } from "theme-ui"
+
+type ItemProps = {
+  name: string
+  content: string
+}
+
+const ProjectInfoItem = ({ name, content }: ItemProps) => (
+  <Flex
+    sx={{
+      flexDirection: `column`,
+      "&:not(:last-of-type)": {
+        mr: 5,
+      },
+      mb: 2,
+    }}
+  >
+    <div
+      sx={{
+        textTransform: `uppercase`,
+        color: `primary`,
+        letterSpacing: `wider`,
+        fontWeight: `semibold`,
+      }}
+    >
+      {name}
+    </div>
+    <div sx={{ fontSize: 2 }}>{content}</div>
+  </Flex>
+)
+
+export default ProjectInfoItem

--- a/themes/gatsby-theme-emma/src/components/project-info.tsx
+++ b/themes/gatsby-theme-emma/src/components/project-info.tsx
@@ -1,0 +1,21 @@
+/** @jsx jsx */
+import { Flex, jsx } from "theme-ui"
+import Item from "./project-info-item"
+
+type ProjectInfoProps = {
+  project: {
+    client: string
+    date: string
+    service: string
+  }
+}
+
+const ProjectInfo = ({ project }: ProjectInfoProps) => (
+  <Flex sx={{ mt: 4, mb: [2, 4], flexWrap: `wrap` }}>
+    <Item name="Client" content={project.client} />
+    <Item name="Date" content={project.date} />
+    <Item name="Service" content={project.service} />
+  </Flex>
+)
+
+export default ProjectInfo

--- a/themes/gatsby-theme-emma/src/components/project.tsx
+++ b/themes/gatsby-theme-emma/src/components/project.tsx
@@ -6,6 +6,7 @@ import Layout from "./layout"
 import SEO from "./seo"
 import { ChildImageSharp } from "../types"
 import Hero from "./hero"
+import ProjectInfo from "./project-info"
 
 type Props = {
   data: {
@@ -22,35 +23,6 @@ type Props = {
     }
   }
 }
-
-type ItemProps = {
-  name: string
-  content: string
-}
-
-const Item = ({ name, content }: ItemProps) => (
-  <Flex
-    sx={{
-      flexDirection: `column`,
-      "&:not(:last-of-type)": {
-        mr: 5,
-      },
-      mb: 2,
-    }}
-  >
-    <div
-      sx={{
-        textTransform: `uppercase`,
-        color: `primary`,
-        letterSpacing: `wider`,
-        fontWeight: `semibold`,
-      }}
-    >
-      {name}
-    </div>
-    <div sx={{ fontSize: 2 }}>{content}</div>
-  </Flex>
-)
 
 const Project = ({ data: { project } }: Props) => {
   const titleProps = useSpring({
@@ -92,11 +64,7 @@ const Project = ({ data: { project } }: Props) => {
             <Styled.h1>{project.title}</Styled.h1>
           </animated.div>
           <animated.div style={infoProps}>
-            <Flex sx={{ mt: 4, mb: [2, 4], flexWrap: `wrap` }}>
-              <Item name="Client" content={project.client} />
-              <Item name="Date" content={project.date} />
-              <Item name="Service" content={project.service} />
-            </Flex>
+            <ProjectInfo project={project} />
           </animated.div>
         </Flex>
       </Hero>


### PR DESCRIPTION
Move the Item and generally speaking the ProjectInfo out of the project template so that it can be shadowed more easily. Before the 3 titles were hardcoded, now you can also pipe in other content into the info section (other source than frontmatter).