### PR TITLE
feat(gatsby-theme-specimens): Add previewText prop

### DIFF
--- a/examples/specimens/src/gatsby-plugin-theme-ui/components.js
+++ b/examples/specimens/src/gatsby-plugin-theme-ui/components.js
@@ -59,10 +59,10 @@ const components = {
   Download: ({ name, src, bg, preview, notes }) => (
     <Download name={name} src={src} bg={bg} preview={preview} notes={notes} />
   ),
-  FontFamily: ({ fonts }) => <FontFamily fonts={fonts} />,
+  FontFamily: ({ fonts, previewText }) => <FontFamily fonts={fonts} previewText={previewText} />,
   FontSize: ({ fontSizes }) => <FontSize fontSizes={fontSizes} />,
-  FontWeight: ({ fontWeights }) => <FontWeight fontWeights={fontWeights} />,
-  Heading: ({ styles, theme }) => <Heading styles={styles} theme={theme} />,
+  FontWeight: ({ fontWeights, previewText }) => <FontWeight fontWeights={fontWeights} previewText={previewText} />,
+  Heading: ({ styles, theme, previewText }) => <Heading styles={styles} theme={theme} previewText={previewText} />,
   Palette: ({ colors, mode, single, minimal, prefix }) => (
     <Palette colors={colors} mode={mode} single={single} minimal={minimal} prefix={prefix} />
   ),

--- a/examples/specimens/src/pages/index.mdx
+++ b/examples/specimens/src/pages/index.mdx
@@ -195,6 +195,7 @@ Variant: `typography.fontFamily`
 Available props:
 
 - fonts
+- previewText (string) (optional) - Replace "The quick brown fox jumps over the lazy dog" with something custom
 
 fonts has to be in the following format:
 
@@ -246,6 +247,7 @@ Variant: `typography.fontWeight`
 Available props:
 
 - fontWeights
+- previewText (string) (optional) - Replace "The quick brown fox jumps over the lazy dog" with something custom
 
 fontWeights has to be in the following format:
 
@@ -277,6 +279,7 @@ Available props:
 
 - styles
 - theme
+- previewText (string) (optional) - Replace "Heading" with something custom
 
 If you're already using Theme UI your theme file already has all necessary keys (styles, fontSizes, fontWeights, fonts). As you can see in the below example the `theme.styles` has entries like `h1` which then will be used to display.
 

--- a/themes/gatsby-theme-specimens/README.md
+++ b/themes/gatsby-theme-specimens/README.md
@@ -183,10 +183,16 @@ export default {
   Download: ({ name, src, bg, preview, notes }) => (
     <Download name={name} src={src} bg={bg} preview={preview} notes={notes} />
   ),
-  FontFamily: ({ fonts }) => <FontFamily fonts={fonts} />,
+  FontFamily: ({ fonts, previewText }) => (
+    <FontFamily fonts={fonts} previewText={previewText} />
+  ),
   FontSize: ({ fontSizes }) => <FontSize fontSizes={fontSizes} />,
-  FontWeight: ({ fontWeights }) => <FontWeight fontWeights={fontWeights} />,
-  Heading: ({ styles, theme }) => <Heading styles={styles} theme={theme} />,
+  FontWeight: ({ fontWeights, previewText }) => (
+    <FontWeight fontWeights={fontWeights} previewText={previewText} />
+  ),
+  Heading: ({ styles, theme, previewText }) => (
+    <Heading styles={styles} theme={theme} previewText={previewText} />
+  ),
   Palette: ({ colors, mode, single, minimal, prefix }) => (
     <Palette
       colors={colors}

--- a/themes/gatsby-theme-specimens/src/components/fontFamily.tsx
+++ b/themes/gatsby-theme-specimens/src/components/fontFamily.tsx
@@ -7,9 +7,10 @@ import theme from "../theme"
 
 interface FontFamilyProps {
   fonts?: ObjectOrArray<CSS.FontFamilyProperty>
+  previewText?: string
 }
 
-const FontFamily = ({ fonts }: FontFamilyProps) => (
+const FontFamily = ({ fonts, previewText = `The quick brown fox jumps over the lazy dog` }: FontFamilyProps) => (
   <Table
     columns={[`100px 1fr`, `100px 300px 1fr`, `100px 350px 1fr`, `100px 450px 1fr`]}
     titles={[`Token`, `Value`, `Preview`]}
@@ -25,9 +26,7 @@ const FontFamily = ({ fonts }: FontFamilyProps) => (
         <div key={key}>
           <div>{key}</div>
           <div sx={{ fontSize: theme.fontSizes[0] }}>{value}</div>
-          <div sx={{ fontFamily: value, fontSize: [theme.fontSizes[1], theme.fontSizes[2]] }}>
-            Pack my box with five dozen liquor jugs
-          </div>
+          <div sx={{ fontFamily: value, fontSize: [theme.fontSizes[1], theme.fontSizes[2]] }}>{previewText}</div>
         </div>
       ))
     ) : (

--- a/themes/gatsby-theme-specimens/src/components/fontWeight.tsx
+++ b/themes/gatsby-theme-specimens/src/components/fontWeight.tsx
@@ -7,9 +7,10 @@ import theme from "../theme"
 
 type FontWeightProps = {
   fontWeights?: ObjectOrArray<CSS.FontWeightProperty>
+  previewText?: string
 }
 
-const FontWeight = ({ fontWeights }: FontWeightProps) => (
+const FontWeight = ({ fontWeights, previewText = `The quick brown fox jumps over the lazy dog` }: FontWeightProps) => (
   <Table
     columns={[`110px 1fr`, `110px 80px 1fr`]}
     titles={[`Token`, `Value`, `Preview`]}
@@ -26,9 +27,7 @@ const FontWeight = ({ fontWeights }: FontWeightProps) => (
         <div key={key}>
           <div>{key}</div>
           <div>{value}</div>
-          <div sx={{ fontWeight: value, fontSize: [theme.fontSizes[1], theme.fontSizes[2]] }}>
-            Pack my box with five dozen liquor jugs
-          </div>
+          <div sx={{ fontWeight: value, fontSize: [theme.fontSizes[1], theme.fontSizes[2]] }}>{previewText}</div>
         </div>
       ))
     ) : (

--- a/themes/gatsby-theme-specimens/src/components/heading.tsx
+++ b/themes/gatsby-theme-specimens/src/components/heading.tsx
@@ -24,6 +24,7 @@ type HeadingProps = {
     h6: headingType
   }
   theme?: any
+  previewText?: string
 }
 
 const infoStyles = {
@@ -32,7 +33,7 @@ const infoStyles = {
   alignItems: `flex-start`,
 }
 
-const Heading = ({ styles, theme }: HeadingProps) => {
+const Heading = ({ styles, theme, previewText = `Heading` }: HeadingProps) => {
   const specimensConfig = useSpecimensConfig()
 
   return (
@@ -73,7 +74,7 @@ const Heading = ({ styles, theme }: HeadingProps) => {
                 mb: themeConfig.space[4],
               }}
             >
-              Heading
+              {previewText}
             </div>
             <div
               data-name="heading-info"


### PR DESCRIPTION
Fixes #219 

Adds the `previewText` prop to fontFamily, fontWeight, and heading component. Allows the user to overwrite the standard text (The quick brown fox jumps over the lazy dog)