### PR TITLE
[Minimal Blog] Icon links in `SEO` interfere with gatsby-plugin-manifest settings

### DIFF
--- a/themes/gatsby-theme-minimal-blog/src/components/seo.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/seo.tsx
@@ -56,9 +56,6 @@ const SEO = ({ title, description, pathname, image, children }: Props) => {
       <meta name="twitter:image:alt" content={seo.description} />
       <meta name="twitter:creator" content={author} />
       <meta name="gatsby-theme" content="@lekoarts/gatsby-theme-minimal-blog" />
-      <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-      <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-      <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
       {children}
     </Helmet>
   )


### PR DESCRIPTION
Hi! I'm really liking your templates! I'm using Minimal Blog. I configured gatsby-plugin-manifest to use a custom image for my favicon. I noticed that some of the `<link>` tags in the `SEO` component seem to prevent manifest's icon settings from working. In development mode I see my own icon appear for a fraction of a second before being replaced with the icon referenced in `SEO`. The manifest plugin injects its own icon `<link>` tags - IIUC it would be better to rely on those tags than to specify icon settings in `SEO`.