### PR TITLE
[Minimal Blog] Slugified anchors on post headings

### DIFF
--- a/cypress/e2e/minimal-blog.ts
+++ b/cypress/e2e/minimal-blog.ts
@@ -112,6 +112,13 @@ describe(`gatsby-theme-minimal-blog`, () => {
       .get(`[data-language="jsx"]`)
       .should(`exist`)
   })
+  it(`should render blogpost headings with slugified anchors`, () => {
+    cy.visit(`/harry-potter-and-the-half-blood-prince`)
+      .assertRoute(`/harry-potter-and-the-half-blood-prince`)
+      .waitForRouteChange()
+      .get(`h2[id=header-2]`)
+      .should(`exist`)
+  })
   it(`should accept custom slug in frontmatter and use that as URL`, () => {
     cy.findByText(
       `Curses and Counter-curses (Bewitch Your Friends and Befuddle Your Enemies with the Latest Revenges: Hair Loss, Jelly-Legs, Tongue-Tying, and Much, Much More)`

--- a/themes/gatsby-theme-minimal-blog-core/gatsby-config.js
+++ b/themes/gatsby-theme-minimal-blog-core/gatsby-config.js
@@ -1,3 +1,4 @@
+const remarkSlug = require(`remark-slug`)
 const withDefaults = require(`./utils/default-options`)
 
 module.exports = themeOptions => {
@@ -43,6 +44,7 @@ module.exports = themeOptions => {
               },
             },
           ],
+          remarkPlugins: [remarkSlug],
         },
       },
       `gatsby-transformer-sharp`,

--- a/themes/gatsby-theme-minimal-blog-core/package.json
+++ b/themes/gatsby-theme-minimal-blog-core/package.json
@@ -29,7 +29,8 @@
     "gatsby-remark-images": "^3.1.42",
     "gatsby-source-filesystem": "^2.1.46",
     "gatsby-transformer-sharp": "^2.3.13",
-    "lodash.kebabcase": "^4.1.1"
+    "lodash.kebabcase": "^4.1.1",
+    "remark-slug": "^5.1.2"
   },
   "keywords": [
     "gatsby",


### PR DESCRIPTION
This change introduces the `remark-slug` plugin to `gatsby-theme-minimal-blog-core` which adds `id` attributes to headings in mdx content. This is highly useful for linking to specific sections in pages using URLs with fragments. (It's also included in `gatsby-theme-blog-core`.)

In addition to the deep-linking capability I personally want to use a table of contents on my blog. (I'm following [this guide](https://johno.com/mdx-table-of-contents-components-in-gatsby).) I can shadow components to make the headings structure available as a post prop - but I need `id` attributes on headings for table-of-contents links to work, and I don't know of any way for me to enable the `remark-slug` plugin without patching the underlying theme.