### PR TITLE
Use user's dark-mode preference

### DIFF
--- a/themes/gatsby-theme-minimal-blog/src/gatsby-plugin-theme-ui/index.js
+++ b/themes/gatsby-theme-minimal-blog/src/gatsby-plugin-theme-ui/index.js
@@ -40,6 +40,7 @@ const headingStyles = {
 export default {
   ...tailwind,
   initialColorMode: `light`,
+  useColorSchemeMediaQuery: true,
   useCustomProperties: true,
   colors: {
     ...tailwind.colors,


### PR DESCRIPTION
`theme-ui` has the option to set light mode vs dark mode according to the user's preference: https://theme-ui.com/color-modes#initialize-mode-with-prefers-color-scheme-media-query

Adding
```
  useColorSchemeMediaQuery: true,
```
initializes dark mode if the `prefers-color-scheme` returns `dark`.