### PR TITLE
Allow subfolders inside postsPath

### DIFF
--- a/themes/gatsby-theme-minimal-blog-core/README.md
+++ b/themes/gatsby-theme-minimal-blog-core/README.md
@@ -40,14 +40,15 @@ npm install @lekoarts/gatsby-theme-minimal-blog-core
 
 ### Theme options
 
-| Key         | Default Value   | Description                                                                                               |
-| ----------- | --------------- | --------------------------------------------------------------------------------------------------------- |
-| `basePath`  | `/`             | Root url for the theme                                                                                    |
-| `blogPath`  | `/blog`         | url for the blog post overview page                                                                       |
-| `tagsPath`  | `/tags`         | url for the tags overview page and prefix for tags (e.g. `/tags/my-tag`)                                  |
-| `postsPath` | `content/posts` | Location of posts                                                                                         |
-| `pagesPath` | `content/pages` | Location of additional pages (optional)                                                                   |
-| `mdx`       | `true`          | Configure `gatsby-plugin-mdx` (if your website already is using the plugin pass `false` to turn this off) |
+| Key                      | Default Value   | Description                                                                                               |
+| ------------------------ | --------------- | --------------------------------------------------------------------------------------------------------- |
+| `basePath`               | `/`             | Root url for the theme                                                                                    |
+| `blogPath`               | `/blog`         | url for the blog post overview page                                                                       |
+| `additionalPostsFolders` | `[]`            | blog path subfolders (if any). For example: `["drafts"]`                                                  |
+| `tagsPath`               | `/tags`         | url for the tags overview page and prefix for tags (e.g. `/tags/my-tag`)                                  |
+| `postsPath`              | `content/posts` | Location of posts                                                                                         |
+| `pagesPath`              | `content/pages` | Location of additional pages (optional)                                                                   |
+| `mdx`                    | `true`          | Configure `gatsby-plugin-mdx` (if your website already is using the plugin pass `false` to turn this off) |
 
 The usage of `content/pages` is optional.
 

--- a/themes/gatsby-theme-minimal-blog-core/gatsby-node.js
+++ b/themes/gatsby-theme-minimal-blog-core/gatsby-node.js
@@ -1,79 +1,71 @@
-const fs = require(`fs`);
-const kebabCase = require(`lodash.kebabcase`);
-const mkdirp = require(`mkdirp`);
-const path = require(`path`);
-const withDefaults = require(`./utils/default-options`);
+const fs = require(`fs`)
+const kebabCase = require(`lodash.kebabcase`)
+const mkdirp = require(`mkdirp`)
+const path = require(`path`)
+const withDefaults = require(`./utils/default-options`)
 
 // Ensure that content directories exist at site-level
 // If non-existent they'll be created here (as empty folders)
 exports.onPreBootstrap = ({ reporter, store }, themeOptions) => {
-  const { program } = store.getState();
+  const { program } = store.getState()
 
-  const { postsPath, pagesPath } = withDefaults(themeOptions);
+  const { postsPath, pagesPath } = withDefaults(themeOptions)
 
-  const dirs = [
-    path.join(program.directory, postsPath),
-    path.join(program.directory, pagesPath)
-  ];
+  const dirs = [path.join(program.directory, postsPath), path.join(program.directory, pagesPath)]
 
   dirs.forEach(dir => {
     if (!fs.existsSync(dir)) {
-      reporter.info(`Initializing "${dir}" directory`);
-      mkdirp.sync(dir);
+      reporter.info(`Initializing "${dir}" directory`)
+      mkdirp.sync(dir)
     }
-  });
-};
+  })
+}
 
-const mdxResolverPassthrough = fieldName => async (
-  source,
-  args,
-  context,
-  info
-) => {
-  const type = info.schema.getType(`Mdx`);
+const mdxResolverPassthrough = fieldName => async (source, args, context, info) => {
+  const type = info.schema.getType(`Mdx`)
   const mdxNode = context.nodeModel.getNodeById({
-    id: source.parent
-  });
-  const resolver = type.getFields()[fieldName].resolve;
+    id: source.parent,
+  })
+  const resolver = type.getFields()[fieldName].resolve
   const result = await resolver(mdxNode, args, context, {
-    fieldName
-  });
-  return result;
-};
+    fieldName,
+  })
+  return result
+}
 
 // Create general interfaces that you could can use to leverage other data sources
 // The core theme sets up MDX as a type for the general interface
 exports.createSchemaCustomization = ({ actions, schema }, themeOptions) => {
-  const { createTypes, createFieldExtension } = actions;
+  const { createTypes, createFieldExtension } = actions
 
-  const { basePath } = withDefaults(themeOptions);
+  const { basePath } = withDefaults(themeOptions)
 
   const slugify = source => {
-    const slug = source.slug ? source.slug : kebabCase(source.title);
+    const slug = source.slug ? source.slug : kebabCase(source.title)
 
-    return `/${basePath}/${slug}`.replace(/\/\/+/g, `/`);
-  };
+    return `/${basePath}/${slug}`.replace(/\/\/+/g, `/`)
+  }
 
   createFieldExtension({
     name: `slugify`,
     extend() {
       return {
-        resolve: slugify
-      };
-    }
-  });
+        resolve: slugify,
+      }
+    },
+  })
 
   createFieldExtension({
     name: `mdxpassthrough`,
     args: {
-      fieldName: `String!`
+      fieldName: `String!`,
     },
     extend({ fieldName }) {
       return {
-        resolve: mdxResolverPassthrough(fieldName)
-      };
-    }
-  });
+        resolve: mdxResolverPassthrough(fieldName),
+      }
+    },
+  })
 
   createTypes(`
     interface Post @nodeInterface {
@@ -143,11 +135,11 @@ exports.createSchemaCustomization = ({ actions, schema }, themeOptions) => {
       title: String!
       slug: String!
     }
-  `);
-};
+  `)
+}
 
 exports.sourceNodes = ({ actions, createContentDigest }, themeOptions) => {
-  const { createNode } = actions;
+  const { createNode } = actions
   const {
     basePath,
     blogPath,
@@ -156,8 +148,8 @@ exports.sourceNodes = ({ actions, createContentDigest }, themeOptions) => {
     tagsPath,
     externalLinks,
     navigation,
-    showLineNumbers
-  } = withDefaults(themeOptions);
+    showLineNumbers,
+  } = withDefaults(themeOptions)
 
   const minimalBlogConfig = {
     basePath,
@@ -167,8 +159,8 @@ exports.sourceNodes = ({ actions, createContentDigest }, themeOptions) => {
     tagsPath,
     externalLinks,
     navigation,
-    showLineNumbers
-  };
+    showLineNumbers,
+  }
 
   createNode({
     ...minimalBlogConfig,
@@ -179,43 +171,38 @@ exports.sourceNodes = ({ actions, createContentDigest }, themeOptions) => {
       type: `MinimalBlogConfig`,
       contentDigest: createContentDigest(minimalBlogConfig),
       content: JSON.stringify(minimalBlogConfig),
-      description: `Options for @lekoarts/gatsby-theme-minimal-blog-core`
-    }
-  });
-};
+      description: `Options for @lekoarts/gatsby-theme-minimal-blog-core`,
+    },
+  })
+}
 
-exports.onCreateNode = (
-  { node, actions, getNode, createNodeId, createContentDigest },
-  themeOptions
-) => {
-  const { createNode, createParentChildLink } = actions;
+exports.onCreateNode = ({ node, actions, getNode, createNodeId, createContentDigest }, themeOptions) => {
+  const { createNode, createParentChildLink } = actions
 
-  const { postsPath, pagesPath, additionalPostsFolders } = withDefaults(
-    themeOptions
-  );
+  const { postsPath, pagesPath, additionalPostsFolders } = withDefaults(themeOptions)
 
   // Make sure that it's an MDX node
   if (node.internal.type !== `Mdx`) {
-    return;
+    return
   }
 
   // Create a source field
   // And grab the sourceInstanceName to differentiate the different sources
   // In this case "postsPath" and "pagesPath"
-  const fileNode = getNode(node.parent);
-  const source = fileNode.sourceInstanceName;
+  const fileNode = getNode(node.parent)
+  const source = fileNode.sourceInstanceName
 
   // Check for "posts" and create the "Post" type
   if (source === postsPath || additionalPostsFolders.includes(source)) {
-    let modifiedTags;
+    let modifiedTags
 
     if (node.frontmatter.tags) {
       modifiedTags = node.frontmatter.tags.map(tag => ({
         name: tag,
-        slug: kebabCase(tag)
-      }));
+        slug: kebabCase(tag),
+      }))
     } else {
-      modifiedTags = null;
+      modifiedTags = null
     }
 
     const fieldData = {
@@ -224,10 +211,10 @@ exports.onCreateNode = (
       date: node.frontmatter.date,
       tags: modifiedTags,
       banner: node.frontmatter.banner,
-      description: node.frontmatter.description
-    };
+      description: node.frontmatter.description,
+    }
 
-    const mdxPostId = createNodeId(`${node.id} >>> MdxPost`);
+    const mdxPostId = createNodeId(`${node.id} >>> MdxPost`)
 
     createNode({
       ...fieldData,
@@ -239,21 +226,21 @@ exports.onCreateNode = (
         type: `MdxPost`,
         contentDigest: createContentDigest(fieldData),
         content: JSON.stringify(fieldData),
-        description: `Mdx implementation of the Post interface`
-      }
-    });
+        description: `Mdx implementation of the Post interface`,
+      },
+    })
 
-    createParentChildLink({ parent: node, child: getNode(mdxPostId) });
+    createParentChildLink({ parent: node, child: getNode(mdxPostId) })
   }
 
   // Check for "pages" and create the "Page" type
   if (node.internal.type === `Mdx` && source === pagesPath) {
     const fieldData = {
       title: node.frontmatter.title,
-      slug: node.frontmatter.slug
-    };
+      slug: node.frontmatter.slug,
+    }
 
-    const mdxPageId = createNodeId(`${node.id} >>> MdxPage`);
+    const mdxPageId = createNodeId(`${node.id} >>> MdxPage`)
 
     createNode({
       ...fieldData,
@@ -265,41 +252,41 @@ exports.onCreateNode = (
         type: `MdxPage`,
         contentDigest: createContentDigest(fieldData),
         content: JSON.stringify(fieldData),
-        description: `Mdx implementation of the Page interface`
-      }
-    });
+        description: `Mdx implementation of the Page interface`,
+      },
+    })
 
-    createParentChildLink({ parent: node, child: getNode(mdxPageId) });
+    createParentChildLink({ parent: node, child: getNode(mdxPageId) })
   }
-};
+}
 
 // These template are only data-fetching wrappers that import components
-const homepageTemplate = require.resolve(`./src/templates/homepage-query.tsx`);
-const blogTemplate = require.resolve(`./src/templates/blog-query.tsx`);
-const postTemplate = require.resolve(`./src/templates/post-query.tsx`);
-const pageTemplate = require.resolve(`./src/templates/page-query.tsx`);
-const tagTemplate = require.resolve(`./src/templates/tag-query.tsx`);
-const tagsTemplate = require.resolve(`./src/templates/tags-query.tsx`);
+const homepageTemplate = require.resolve(`./src/templates/homepage-query.tsx`)
+const blogTemplate = require.resolve(`./src/templates/blog-query.tsx`)
+const postTemplate = require.resolve(`./src/templates/post-query.tsx`)
+const pageTemplate = require.resolve(`./src/templates/page-query.tsx`)
+const tagTemplate = require.resolve(`./src/templates/tag-query.tsx`)
+const tagsTemplate = require.resolve(`./src/templates/tags-query.tsx`)
 
 exports.createPages = async ({ actions, graphql, reporter }, themeOptions) => {
-  const { createPage } = actions;
+  const { createPage } = actions
 
-  const { basePath, blogPath, tagsPath } = withDefaults(themeOptions);
+  const { basePath, blogPath, tagsPath } = withDefaults(themeOptions)
 
   createPage({
     path: basePath,
-    component: homepageTemplate
-  });
+    component: homepageTemplate,
+  })
 
   createPage({
     path: `/${basePath}/${blogPath}`.replace(/\/\/+/g, `/`),
-    component: blogTemplate
-  });
+    component: blogTemplate,
+  })
 
   createPage({
     path: `/${basePath}/${tagsPath}`.replace(/\/\/+/g, `/`),
-    component: tagsTemplate
-  });
+    component: tagsTemplate,
+  })
 
   const result = await graphql(`
     query {
@@ -319,29 +306,26 @@ exports.createPages = async ({ actions, graphql, reporter }, themeOptions) => {
         }
       }
     }
-  `);
+  `)
 
   if (result.errors) {
-    reporter.panicOnBuild(
-      `There was an error loading your posts or pages`,
-      result.errors
-    );
-    return;
+    reporter.panicOnBuild(`There was an error loading your posts or pages`, result.errors)
+    return
   }
 
-  const posts = result.data.allPost.nodes;
+  const posts = result.data.allPost.nodes
 
   posts.forEach(post => {
     createPage({
       path: post.slug,
       component: postTemplate,
       context: {
-        slug: post.slug
-      }
-    });
-  });
+        slug: post.slug,
+      },
+    })
+  })
 
-  const pages = result.data.allPage.nodes;
+  const pages = result.data.allPage.nodes
 
   if (pages.length > 0) {
     pages.forEach(page => {
@@ -349,27 +333,24 @@ exports.createPages = async ({ actions, graphql, reporter }, themeOptions) => {
         path: `/${basePath}/${page.slug}`.replace(/\/\/+/g, `/`),
         component: pageTemplate,
         context: {
-          slug: page.slug
-        }
-      });
-    });
+          slug: page.slug,
+        },
+      })
+    })
   }
 
-  const tags = result.data.tags.group;
+  const tags = result.data.tags.group
 
   if (tags.length > 0) {
     tags.forEach(tag => {
       createPage({
-        path: `/${basePath}/${tagsPath}/${kebabCase(tag.fieldValue)}`.replace(
-          /\/\/+/g,
-          `/`
-        ),
+        path: `/${basePath}/${tagsPath}/${kebabCase(tag.fieldValue)}`.replace(/\/\/+/g, `/`),
         component: tagTemplate,
         context: {
           slug: kebabCase(tag.fieldValue),
-          name: tag.fieldValue
-        }
-      });
-    });
+          name: tag.fieldValue,
+        },
+      })
+    })
   }
-};
+}

--- a/themes/gatsby-theme-minimal-blog-core/package.json
+++ b/themes/gatsby-theme-minimal-blog-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lekoarts/gatsby-theme-minimal-blog-core",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "author": "LekoArts <hello@lekoarts.de>",
   "description": "Core Theme for @lekoarts/gatsby-theme-minimal-blog. This theme implements the Post and Page node interfaces and exports templates (+ queries) which you can shadow.",
   "license": "MIT",

--- a/themes/gatsby-theme-minimal-blog-core/utils/default-options.js
+++ b/themes/gatsby-theme-minimal-blog-core/utils/default-options.js
@@ -1,12 +1,13 @@
 module.exports = themeOptions => {
-  const basePath = themeOptions.basePath || `/`
-  const blogPath = themeOptions.blogPath || `/blog`
-  const postsPath = themeOptions.postsPath || `content/posts`
-  const pagesPath = themeOptions.pagesPath || `content/pages`
-  const tagsPath = themeOptions.tagsPath || `/tags`
-  const externalLinks = themeOptions.externalLinks || []
-  const navigation = themeOptions.navigation || []
-  const showLineNumbers = themeOptions.showLineNumbers || true
+  const basePath = themeOptions.basePath || `/`;
+  const blogPath = themeOptions.blogPath || `/blog`;
+  const postsPath = themeOptions.postsPath || `content/posts`;
+  const pagesPath = themeOptions.pagesPath || `content/pages`;
+  const tagsPath = themeOptions.tagsPath || `/tags`;
+  const additionalPostsFolders = themeOptions.additionalPostsFolders || [];
+  const externalLinks = themeOptions.externalLinks || [];
+  const navigation = themeOptions.navigation || [];
+  const showLineNumbers = themeOptions.showLineNumbers || true;
 
   return {
     basePath,
@@ -14,8 +15,9 @@ module.exports = themeOptions => {
     postsPath,
     pagesPath,
     tagsPath,
+    additionalPostsFolders,
     externalLinks,
     navigation,
-    showLineNumbers,
-  }
-}
+    showLineNumbers
+  };
+};

--- a/themes/gatsby-theme-minimal-blog-core/utils/default-options.js
+++ b/themes/gatsby-theme-minimal-blog-core/utils/default-options.js
@@ -1,23 +1,23 @@
 module.exports = themeOptions => {
-  const basePath = themeOptions.basePath || `/`;
-  const blogPath = themeOptions.blogPath || `/blog`;
-  const postsPath = themeOptions.postsPath || `content/posts`;
-  const pagesPath = themeOptions.pagesPath || `content/pages`;
-  const tagsPath = themeOptions.tagsPath || `/tags`;
+  const basePath = themeOptions.basePath || `/`
+  const blogPath = themeOptions.blogPath || `/blog`
+  const postsPath = themeOptions.postsPath || `content/posts`
   const additionalPostsFolders = themeOptions.additionalPostsFolders || [];
-  const externalLinks = themeOptions.externalLinks || [];
-  const navigation = themeOptions.navigation || [];
-  const showLineNumbers = themeOptions.showLineNumbers || true;
+  const pagesPath = themeOptions.pagesPath || `content/pages`
+  const tagsPath = themeOptions.tagsPath || `/tags`
+  const externalLinks = themeOptions.externalLinks || []
+  const navigation = themeOptions.navigation || []
+  const showLineNumbers = themeOptions.showLineNumbers || true
 
   return {
     basePath,
     blogPath,
     postsPath,
+    additionalPostsFolders,
     pagesPath,
     tagsPath,
-    additionalPostsFolders,
     externalLinks,
     navigation,
-    showLineNumbers
-  };
-};
+    showLineNumbers,
+  }
+}

--- a/themes/gatsby-theme-minimal-blog/package.json
+++ b/themes/gatsby-theme-minimal-blog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lekoarts/gatsby-theme-minimal-blog",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "author": "LekoArts <hello@lekoarts.de>",
   "description": "Typography driven, feature-rich blogging theme with minimal aesthetics. Includes tags/categories support and extensive features for code blocks such as live preview, line numbers, and line highlighting.",
   "license": "MIT",
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@emotion/core": "^10.0.27",
-    "@lekoarts/gatsby-theme-minimal-blog-core": "^2.0.1",
+    "@lekoarts/gatsby-theme-minimal-blog-core": "^2.1.0",
     "@loadable/component": "^5.12.0",
     "@mdx-js/react": "^1.5.5",
     "@theme-ui/color": "^0.2.53",


### PR DESCRIPTION
Hello 👋 

First of all, thanks a lot for the minimal-blog theme 🙏 It's a wonderful theme!

## Motivation

I've make this PR because I wanted to have my posts organized by subfolders. Something like this:
```
content/
  posts/
  stories/
  events/
  drafts/
```

I tried to make the less thing possible to work. But I'm open to other solutions 😅 

## What this PR do

It adds a new (optional) configuration option `additionalPostsFolders` with an array of subfolder names to be searched for posts.

## Usage

In the `gatsby-config.js`:

```
  plugins: [
    {
      resolve: `@lekoarts/gatsby-theme-minimal-blog`,
      options: {
        basePath: `/`,
        blogPath: `/blog`,
        postsPath: `content`,
        additionalPostsFolders: [`posts`, `stories`, `events`, `drafts`],
        ...
```

