### PR TITLE
feat: Add `formatString` option

### DIFF
--- a/themes/gatsby-theme-emilia-core/README.md
+++ b/themes/gatsby-theme-emilia-core/README.md
@@ -50,6 +50,7 @@ npm install @lekoarts/gatsby-theme-emilia-core
 | `location`        | `Germany`                                                                                                                                     | Shown below the title                                                                                                                             |
 | `socialMedia`     | `` [{ title: `Twitter`, href: `https://twitter.com/lekoarts_de` }, { title: `Instagram`, href: `https://www.instagram.com/lekoarts.de/` }] `` | An array of objects (with the keys "title" and "href" display on the homepage. Can of course hold any kind of links (not limited to social media) |
 | `showThemeAuthor` | `true`                                                                                                                                        | Show the "Theme by LekoArts" in the footer                                                                                                        |
+| `formatString`    | `DD.MM.YYYY`                                                                                                                                  | Configure the date format for Date fields                                                                                                         |
 
 ### Shadowing
 

--- a/themes/gatsby-theme-emilia-core/gatsby-node.js
+++ b/themes/gatsby-theme-emilia-core/gatsby-node.js
@@ -192,7 +192,7 @@ const projectTemplate = require.resolve(`./src/templates/project-query.tsx`)
 exports.createPages = async ({ actions, graphql, reporter }, themeOptions) => {
   const { createPage } = actions
 
-  const { basePath } = withDefaults(themeOptions)
+  const { basePath, formatString } = withDefaults(themeOptions)
 
   createPage({
     path: basePath,
@@ -251,6 +251,7 @@ exports.createPages = async ({ actions, graphql, reporter }, themeOptions) => {
         absolutePathRegex: `/^${path.dirname(fileAbsolutePath)}/`,
         prev,
         next,
+        formatString,
       },
     })
   })

--- a/themes/gatsby-theme-emilia-core/src/templates/project-query.tsx
+++ b/themes/gatsby-theme-emilia-core/src/templates/project-query.tsx
@@ -4,7 +4,7 @@ import ProjectComponent from "../components/project"
 export default ProjectComponent
 
 export const query = graphql`
-  query($slug: String!, $absolutePathRegex: String!) {
+  query($slug: String!, $absolutePathRegex: String!, $formatString: String!) {
     images: allFile(
       filter: {
         absolutePath: { regex: $absolutePathRegex }
@@ -24,7 +24,7 @@ export const query = graphql`
     project(slug: { eq: $slug }) {
       body
       excerpt
-      date(formatString: "DD.MM.YYYY")
+      date(formatString: $formatString)
       slug
       title
       areas

--- a/themes/gatsby-theme-emilia-core/src/templates/projects-query.tsx
+++ b/themes/gatsby-theme-emilia-core/src/templates/projects-query.tsx
@@ -9,8 +9,6 @@ export const query = graphql`
       nodes {
         slug
         title
-        areas
-        date(formatString: "DD.MM.YYYY")
         cover {
           childImageSharp {
             fluid(maxWidth: 770, quality: 95) {

--- a/themes/gatsby-theme-emilia-core/utils/default-options.js
+++ b/themes/gatsby-theme-emilia-core/utils/default-options.js
@@ -2,10 +2,12 @@ module.exports = themeOptions => {
   const basePath = themeOptions.basePath || `/`
   const projectsPath = themeOptions.projectsPath || `content/projects`
   const assetsPath = themeOptions.projectsPath || `content/assets`
+  const formatString = themeOptions.formatString || `DD.MM.YYYY`
 
   return {
     basePath,
     projectsPath,
     assetsPath,
+    formatString,
   }
 }

--- a/themes/gatsby-theme-emilia/README.md
+++ b/themes/gatsby-theme-emilia/README.md
@@ -72,6 +72,7 @@ gatsby new emilia LekoArts/gatsby-starter-portfolio-emilia
 | `location`        | `Germany`                                                                                                                                     | Shown below the title                                                                                                                             |
 | `socialMedia`     | `` [{ title: `Twitter`, href: `https://twitter.com/lekoarts_de` }, { title: `Instagram`, href: `https://www.instagram.com/lekoarts.de/` }] `` | An array of objects (with the keys "title" and "href" display on the homepage. Can of course hold any kind of links (not limited to social media) |
 | `showThemeAuthor` | `true`                                                                                                                                        | Show the "Theme by LekoArts" in the footer                                                                                                        |
+| `formatString`    | `DD.MM.YYYY`                                                                                                                                  | Configure the date format for Date fields                                                                                                         |
 
 #### Example usage
 

--- a/themes/gatsby-theme-emilia/src/components/projects.tsx
+++ b/themes/gatsby-theme-emilia/src/components/projects.tsx
@@ -12,8 +12,6 @@ type Props = {
   projects: {
     slug: string
     title: string
-    areas: string[]
-    date: string
     cover: ChildImageSharp
   }[]
 }

--- a/themes/gatsby-theme-emma-core/README.md
+++ b/themes/gatsby-theme-emma-core/README.md
@@ -46,6 +46,7 @@ npm install @lekoarts/gatsby-theme-emma-core
 | `projectsPath` | `content/projects` | Location of projects                                                                                      |
 | `pagesPath`    | `content/pages`    | Location of additional pages (optional)                                                                   |
 | `mdx`          | `true`             | Configure `gatsby-plugin-mdx` (if your website already is using the plugin pass `false` to turn this off) |
+| `formatString` | `DD.MM.YYYY`       | Configure the date format for Date fields                                                                 |
 
 The usage of `content/pages` is optional. If no page/MDX file is found the navigation will be hidden.
 

--- a/themes/gatsby-theme-emma-core/gatsby-node.js
+++ b/themes/gatsby-theme-emma-core/gatsby-node.js
@@ -195,7 +195,7 @@ const pageTemplate = require.resolve(`./src/templates/page-query.tsx`)
 exports.createPages = async ({ actions, graphql, reporter }, themeOptions) => {
   const { createPage } = actions
 
-  const { basePath } = withDefaults(themeOptions)
+  const { basePath, formatString } = withDefaults(themeOptions)
 
   createPage({
     path: basePath,
@@ -230,6 +230,7 @@ exports.createPages = async ({ actions, graphql, reporter }, themeOptions) => {
       component: projectTemplate,
       context: {
         slug: project.slug,
+        formatString,
       },
     })
   })

--- a/themes/gatsby-theme-emma-core/src/templates/project-query.tsx
+++ b/themes/gatsby-theme-emma-core/src/templates/project-query.tsx
@@ -4,13 +4,13 @@ import ProjectComponent from "../components/project"
 export default ProjectComponent
 
 export const query = graphql`
-  query($slug: String!) {
+  query($slug: String!, $formatString: String!) {
     project(slug: { eq: $slug }) {
       body
       excerpt
       client
       color
-      date(formatString: "DD.MM.YYYY")
+      date(formatString: $formatString)
       service
       slug
       title

--- a/themes/gatsby-theme-emma-core/utils/default-options.js
+++ b/themes/gatsby-theme-emma-core/utils/default-options.js
@@ -2,10 +2,12 @@ module.exports = themeOptions => {
   const basePath = themeOptions.basePath || `/`
   const projectsPath = themeOptions.projectsPath || `content/projects`
   const pagesPath = themeOptions.pagesPath || `content/pages`
+  const formatString = themeOptions.formatString || `DD.MM.YYYY`
 
   return {
     basePath,
     projectsPath,
     pagesPath,
+    formatString,
   }
 }

--- a/themes/gatsby-theme-emma/README.md
+++ b/themes/gatsby-theme-emma/README.md
@@ -67,6 +67,7 @@ gatsby new emma LekoArts/gatsby-starter-portfolio-emma
 | `projectsPath` | `content/projects` | Location of projects                                                                                      |
 | `pagesPath`    | `content/pages`    | Location of additional pages (optional)                                                                   |
 | `mdx`          | `true`             | Configure `gatsby-plugin-mdx` (if your website already is using the plugin pass `false` to turn this off) |
+| `formatString` | `DD.MM.YYYY`       | Configure the date format for Date fields                                                                 |
 
 The usage of `content/pages` is optional. If no page/MDX file is found the navigation will be hidden.
 

--- a/themes/gatsby-theme-minimal-blog-core/README.md
+++ b/themes/gatsby-theme-minimal-blog-core/README.md
@@ -40,14 +40,15 @@ npm install @lekoarts/gatsby-theme-minimal-blog-core
 
 ### Theme options
 
-| Key         | Default Value   | Description                                                                                               |
-| ----------- | --------------- | --------------------------------------------------------------------------------------------------------- |
-| `basePath`  | `/`             | Root url for the theme                                                                                    |
-| `blogPath`  | `/blog`         | url for the blog post overview page                                                                       |
-| `tagsPath`  | `/tags`         | url for the tags overview page and prefix for tags (e.g. `/tags/my-tag`)                                  |
-| `postsPath` | `content/posts` | Location of posts                                                                                         |
-| `pagesPath` | `content/pages` | Location of additional pages (optional)                                                                   |
-| `mdx`       | `true`          | Configure `gatsby-plugin-mdx` (if your website already is using the plugin pass `false` to turn this off) |
+| Key            | Default Value   | Description                                                                                               |
+| -------------- | --------------- | --------------------------------------------------------------------------------------------------------- |
+| `basePath`     | `/`             | Root url for the theme                                                                                    |
+| `blogPath`     | `/blog`         | url for the blog post overview page                                                                       |
+| `tagsPath`     | `/tags`         | url for the tags overview page and prefix for tags (e.g. `/tags/my-tag`)                                  |
+| `postsPath`    | `content/posts` | Location of posts                                                                                         |
+| `pagesPath`    | `content/pages` | Location of additional pages (optional)                                                                   |
+| `mdx`          | `true`          | Configure `gatsby-plugin-mdx` (if your website already is using the plugin pass `false` to turn this off) |
+| `formatString` | `DD.MM.YYYY`    | Configure the date format for Date fields                                                                 |
 
 The usage of `content/pages` is optional.
 

--- a/themes/gatsby-theme-minimal-blog-core/gatsby-node.js
+++ b/themes/gatsby-theme-minimal-blog-core/gatsby-node.js
@@ -271,16 +271,22 @@ const tagsTemplate = require.resolve(`./src/templates/tags-query.tsx`)
 exports.createPages = async ({ actions, graphql, reporter }, themeOptions) => {
   const { createPage } = actions
 
-  const { basePath, blogPath, tagsPath } = withDefaults(themeOptions)
+  const { basePath, blogPath, tagsPath, formatString } = withDefaults(themeOptions)
 
   createPage({
     path: basePath,
     component: homepageTemplate,
+    context: {
+      formatString,
+    },
   })
 
   createPage({
     path: `/${basePath}/${blogPath}`.replace(/\/\/+/g, `/`),
     component: blogTemplate,
+    context: {
+      formatString,
+    },
   })
 
   createPage({
@@ -321,6 +327,7 @@ exports.createPages = async ({ actions, graphql, reporter }, themeOptions) => {
       component: postTemplate,
       context: {
         slug: post.slug,
+        formatString,
       },
     })
   })
@@ -349,6 +356,7 @@ exports.createPages = async ({ actions, graphql, reporter }, themeOptions) => {
         context: {
           slug: kebabCase(tag.fieldValue),
           name: tag.fieldValue,
+          formatString,
         },
       })
     })

--- a/themes/gatsby-theme-minimal-blog-core/src/templates/blog-query.tsx
+++ b/themes/gatsby-theme-minimal-blog-core/src/templates/blog-query.tsx
@@ -4,12 +4,12 @@ import BlogComponent from "../components/blog"
 export default BlogComponent
 
 export const query = graphql`
-  query {
+  query($formatString: String!) {
     allPost(sort: { fields: date, order: DESC }) {
       nodes {
         slug
         title
-        date(formatString: "DD.MM.YYYY")
+        date(formatString: $formatString)
         tags {
           name
           slug

--- a/themes/gatsby-theme-minimal-blog-core/src/templates/homepage-query.tsx
+++ b/themes/gatsby-theme-minimal-blog-core/src/templates/homepage-query.tsx
@@ -4,12 +4,12 @@ import HomepageComponent from "../components/homepage"
 export default HomepageComponent
 
 export const query = graphql`
-  query {
+  query($formatString: String!) {
     allPost(sort: { fields: date, order: DESC }, limit: 3) {
       nodes {
         slug
         title
-        date(formatString: "DD.MM.YYYY")
+        date(formatString: $formatString)
         tags {
           name
           slug

--- a/themes/gatsby-theme-minimal-blog-core/src/templates/post-query.tsx
+++ b/themes/gatsby-theme-minimal-blog-core/src/templates/post-query.tsx
@@ -4,11 +4,11 @@ import PostComponent from "../components/post"
 export default PostComponent
 
 export const query = graphql`
-  query($slug: String!) {
+  query($slug: String!, $formatString: String!) {
     post(slug: { eq: $slug }) {
       slug
       title
-      date(formatString: "DD.MM.YYYY")
+      date(formatString: $formatString)
       tags {
         name
         slug

--- a/themes/gatsby-theme-minimal-blog-core/src/templates/tag-query.tsx
+++ b/themes/gatsby-theme-minimal-blog-core/src/templates/tag-query.tsx
@@ -4,12 +4,12 @@ import TagComponent from "../components/tag"
 export default TagComponent
 
 export const query = graphql`
-  query($slug: String!) {
+  query($slug: String!, $formatString: String!) {
     allPost(sort: { fields: date, order: DESC }, filter: { tags: { elemMatch: { slug: { eq: $slug } } } }) {
       nodes {
         slug
         title
-        date(formatString: "DD.MM.YYYY")
+        date(formatString: $formatString)
         tags {
           name
           slug

--- a/themes/gatsby-theme-minimal-blog-core/utils/default-options.js
+++ b/themes/gatsby-theme-minimal-blog-core/utils/default-options.js
@@ -7,6 +7,7 @@ module.exports = themeOptions => {
   const externalLinks = themeOptions.externalLinks || []
   const navigation = themeOptions.navigation || []
   const showLineNumbers = themeOptions.showLineNumbers || true
+  const formatString = themeOptions.formatString || `DD.MM.YYYY`
 
   return {
     basePath,
@@ -17,5 +18,6 @@ module.exports = themeOptions => {
     externalLinks,
     navigation,
     showLineNumbers,
+    formatString,
   }
 }

--- a/themes/gatsby-theme-minimal-blog/README.md
+++ b/themes/gatsby-theme-minimal-blog/README.md
@@ -72,6 +72,7 @@ gatsby new minimal-blog LekoArts/gatsby-starter-minimal-blog
 | `postsPath`       | `content/posts` | Location of posts                                                                                         |
 | `pagesPath`       | `content/pages` | Location of additional pages (optional)                                                                   |
 | `mdx`             | `true`          | Configure `gatsby-plugin-mdx` (if your website already is using the plugin pass `false` to turn this off) |
+| `formatString`    | `DD.MM.YYYY`    | Configure the date format for Date fields                                                                 |
 | `showLineNumbers` | `true`          | Show line numbers in code blocks                                                                          |
 | `navigation`      | `[]`            | Add links to your internal sites to the left part of the header                                           |
 | `externalLinks`   | `[]`            | Add links to your external sites to the right part of the header                                          |


### PR DESCRIPTION
Adds a `formatString` option to
- gatsby-theme-minimal-blog-core (and hence also gatsby-theme-minimal-blog)
- gatsby-theme-emilia-core (and hence also gatsby-theme-emilia)
- gatsby-theme-emma-core (and hence also gatsby-theme-emma)

This enables an easy change of the date format in GraphQL queries without the need to shadow every file.

Fixes #273