### PR TITLE
fix: filterStyles & better checks in Heading

### DIFF
--- a/themes/gatsby-theme-specimens/src/components/heading.tsx
+++ b/themes/gatsby-theme-specimens/src/components/heading.tsx
@@ -21,141 +21,152 @@ const infoStyles = {
 const Heading = ({ styles, theme, previewText = `Heading` }: HeadingProps) => {
   const specimensConfig = useSpecimensConfig()
 
+  if (!styles) {
+    return <div sx={{ gridTemplateColumns: `1fr !important` }}>No styles defined</div>
+  }
+
   return (
     <React.Fragment>
-      {Object.entries(styles).map(([key, value]) => {
-        const type = {
-          level: key,
-          fontFamily: value.fontFamily,
-          size: value.fontSize,
-          weight: value.fontWeight,
-          lineHeight: value.lineHeight,
-        }
+      {Object.entries(styles).length !== 0 ? (
+        Object.entries(styles).map(([key, value]) => {
+          const type = {
+            level: key,
+            fontFamily: value.fontFamily,
+            size: value.fontSize,
+            weight: value.fontWeight,
+            lineHeight: value.lineHeight,
+          }
 
-        return (
-          <div
-            key={type.level}
-            sx={{
-              display: `flex`,
-              flexDirection: `column`,
-              borderBottomWidth: `1px`,
-              borderBottomColor: themeConfig.colors.gray[3],
-              borderBottomStyle: `solid`,
-              mb: themeConfig.space[4],
-              pb: themeConfig.space[4],
-              "&:last-child": {
-                borderBottom: `none`,
-              },
-              ...themeConfig.typography.heading,
-            }}
-          >
+          return (
             <div
-              data-name="heading-level-preview"
-              sx={{
-                fontFamily: type.fontFamily,
-                fontSize: `${specimensConfig.rootFontSize * getValue(theme.fontSizes[type.size])}px`,
-                fontWeight: type.weight,
-                lineHeight: type.lineHeight,
-                mb: themeConfig.space[4],
-              }}
-            >
-              {previewText}
-            </div>
-            <div
-              data-name="heading-info"
+              key={type.level}
               sx={{
                 display: `flex`,
-                flexDirection: `row`,
-                flexWrap: `wrap`,
-                justifyContent: `flex-start`,
-                width: `100%`,
-                "> div": {
-                  mr: themeConfig.space[4],
-                  mb: themeConfig.space[2],
+                flexDirection: `column`,
+                borderBottomWidth: `1px`,
+                borderBottomColor: themeConfig.colors.gray[3],
+                borderBottomStyle: `solid`,
+                mb: themeConfig.space[4],
+                pb: themeConfig.space[4],
+                "&:last-child": {
+                  borderBottom: `none`,
                 },
-                span: {
-                  mb: themeConfig.space[2],
-                },
+                ...themeConfig.typography.heading,
               }}
             >
-              <div sx={{ ...infoStyles }}>
-                <Badge>Type</Badge>
-                {type.level}
-              </div>
-              <div sx={{ ...infoStyles }}>
-                <Badge>Token</Badge>
-                {type.size}
-              </div>
-              <div sx={{ ...infoStyles, minWidth: `80px` }}>
-                <Badge>Size</Badge>
-                {theme.fontSizes[type.size]}
-              </div>
-              <div sx={{ ...infoStyles, minWidth: `80px` }}>
-                <Badge>Line Height</Badge>
-                {theme.lineHeights[type.lineHeight]}
-              </div>
-              <div sx={{ ...infoStyles }}>
-                <Badge>Weight</Badge>
-                {theme.fontWeights[type.weight]}
-              </div>
-            </div>
-            {specimensConfig.codeExample && (
               <div
+                data-name="heading-level-preview"
                 sx={{
-                  "code, pre": {
-                    fontFamily: `Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace`,
-                    lineHeight: 1.375,
-                    direction: `ltr`,
-                    textAlign: `left`,
-                    whiteSpace: `pre`,
-                    wordSpacing: `normal`,
-                    wordBreak: `normal`,
-                    hyphens: `none`,
-                    backgroundColor: `#f5f7ff`,
-                    color: `#5e6687`,
-                    padding: themeConfig.space[2],
-                    borderRadius: `default`,
-                    ".token.string": {
-                      color: `#22a2c9`,
-                    },
-                    ".token.punctuation": {
-                      color: `#5e6687`,
-                    },
-                    ".token.operator, .token.boolean, .token.number": {
-                      color: `#c76b29`,
-                    },
-                  },
-                  mt: themeConfig.space[3],
-                  fontSize: themeConfig.fontSizes[0],
-                  width: `100%`,
-                  overflow: `auto`,
-                  ...themeConfig.codeStyles.default,
+                  fontFamily: type.fontFamily,
+                  fontSize: `${specimensConfig.rootFontSize * getValue(theme.fontSizes[type.size])}px`,
+                  fontWeight: type.weight,
+                  lineHeight: type.lineHeight,
+                  mb: themeConfig.space[4],
                 }}
               >
-                <pre sx={{ my: themeConfig.space[0] }}>
-                  <code>
-                    <span className="token punctuation">{`{`}</span>
-                    <span className="token punctuation" /> fontSize<span className="token punctuation">:</span>
-                    {` `}
-                    <span className="token number">{type.size}</span>
-                    <span className="token punctuation">,</span> fontWeight<span className="token punctuation">:</span>
-                    {` `}
-                    <span className="token string">"{type.weight}"</span>
-                    <span className="token punctuation">,</span> lineHeight<span className="token punctuation">:</span>
-                    {` `}
-                    <span className="token string">"{type.lineHeight}"</span>
-                    <span className="token punctuation">,</span> fontFamily<span className="token punctuation">:</span>
-                    {` `}
-                    <span className="token string">"{type.fontFamily}"</span>
-                    {` `}
-                    <span className="token punctuation">{`}`}</span>
-                  </code>
-                </pre>
+                {previewText}
               </div>
-            )}
-          </div>
-        )
-      })}
+              <div
+                data-name="heading-info"
+                sx={{
+                  display: `flex`,
+                  flexDirection: `row`,
+                  flexWrap: `wrap`,
+                  justifyContent: `flex-start`,
+                  width: `100%`,
+                  "> div": {
+                    mr: themeConfig.space[4],
+                    mb: themeConfig.space[2],
+                  },
+                  span: {
+                    mb: themeConfig.space[2],
+                  },
+                }}
+              >
+                <div sx={{ ...infoStyles }}>
+                  <Badge>Type</Badge>
+                  {type.level}
+                </div>
+                <div sx={{ ...infoStyles }}>
+                  <Badge>Token</Badge>
+                  {type.size}
+                </div>
+                <div sx={{ ...infoStyles, minWidth: `80px` }}>
+                  <Badge>Size</Badge>
+                  {theme.fontSizes[type.size]}
+                </div>
+                <div sx={{ ...infoStyles, minWidth: `80px` }}>
+                  <Badge>Line Height</Badge>
+                  {theme.lineHeights[type.lineHeight]}
+                </div>
+                <div sx={{ ...infoStyles }}>
+                  <Badge>Weight</Badge>
+                  {theme.fontWeights[type.weight]}
+                </div>
+              </div>
+              {specimensConfig.codeExample && (
+                <div
+                  sx={{
+                    "code, pre": {
+                      fontFamily: `Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace`,
+                      lineHeight: 1.375,
+                      direction: `ltr`,
+                      textAlign: `left`,
+                      whiteSpace: `pre`,
+                      wordSpacing: `normal`,
+                      wordBreak: `normal`,
+                      hyphens: `none`,
+                      backgroundColor: `#f5f7ff`,
+                      color: `#5e6687`,
+                      padding: themeConfig.space[2],
+                      borderRadius: `default`,
+                      ".token.string": {
+                        color: `#22a2c9`,
+                      },
+                      ".token.punctuation": {
+                        color: `#5e6687`,
+                      },
+                      ".token.operator, .token.boolean, .token.number": {
+                        color: `#c76b29`,
+                      },
+                    },
+                    mt: themeConfig.space[3],
+                    fontSize: themeConfig.fontSizes[0],
+                    width: `100%`,
+                    overflow: `auto`,
+                    ...themeConfig.codeStyles.default,
+                  }}
+                >
+                  <pre sx={{ my: themeConfig.space[0] }}>
+                    <code>
+                      <span className="token punctuation">{`{`}</span>
+                      <span className="token punctuation" /> fontSize<span className="token punctuation">:</span>
+                      {` `}
+                      <span className="token number">{type.size}</span>
+                      <span className="token punctuation">,</span> fontWeight
+                      <span className="token punctuation">:</span>
+                      {` `}
+                      <span className="token string">"{type.weight}"</span>
+                      <span className="token punctuation">,</span> lineHeight
+                      <span className="token punctuation">:</span>
+                      {` `}
+                      <span className="token string">"{type.lineHeight}"</span>
+                      <span className="token punctuation">,</span> fontFamily
+                      <span className="token punctuation">:</span>
+                      {` `}
+                      <span className="token string">"{type.fontFamily}"</span>
+                      {` `}
+                      <span className="token punctuation">{`}`}</span>
+                    </code>
+                  </pre>
+                </div>
+              )}
+            </div>
+          )
+        })
+      ) : (
+        <div sx={{ gridTemplateColumns: `1fr !important` }}>No heading styles defined</div>
+      )}
     </React.Fragment>
   )
 }

--- a/themes/gatsby-theme-specimens/src/utils/filter-styles.ts
+++ b/themes/gatsby-theme-specimens/src/utils/filter-styles.ts
@@ -5,8 +5,23 @@ type filterStylesType = {
   allowed: string[]
 }
 
-const filterStyles = ({ input, allowed }: filterStylesType) =>
-  // @ts-ignore
-  allowed.reduce((obj, key) => ({ ...obj, [key]: input[key] }), {})
+const filterStyles = ({ input, allowed }: filterStylesType) => {
+  if (!input) {
+    return undefined
+  }
+
+  return allowed.reduce((obj, key) => {
+    // If a key is only existing in "allowed" but not in the "input", skip it
+    // Otherwise e.g. h3: undefined will be added
+
+    // @ts-ignore
+    if (!input[key]) {
+      return { ...obj }
+    }
+
+    // @ts-ignore
+    return { ...obj, [key]: input[key] }
+  }, {})
+}
 
 export default filterStyles

--- a/themes/gatsby-theme-styleguide/src/typography.tsx
+++ b/themes/gatsby-theme-styleguide/src/typography.tsx
@@ -20,7 +20,7 @@ const Typography = () => {
         theme={useTheme()}
         styles={filterStyles({
           input: styles,
-          allowed: [`h1`, `h2`, `h3`, `h4`],
+          allowed: [`h1`, `h2`, `h3`, `h4`, `h5`, `h6`],
         })}
       />
     </section>


### PR DESCRIPTION
Fixes #264

The filterStyles function was adding e.g. a `h3: undefined` to the object when `h3` was in the allowed array but not in the input styles.

Also some better checks in the Heading component when the styles object is completely missing or empty (e.g. when no heading styles/allowed is found)