### PR TITLE
fix: Allow customized RSS feed and title

### DIFF
--- a/themes/gatsby-theme-minimal-blog/README.md
+++ b/themes/gatsby-theme-minimal-blog/README.md
@@ -64,18 +64,20 @@ gatsby new minimal-blog LekoArts/gatsby-starter-minimal-blog
 
 ### Theme options
 
-| Key               | Default Value   | Description                                                                                               |
-| ----------------- | --------------- | --------------------------------------------------------------------------------------------------------- |
-| `basePath`        | `/`             | Root url for the theme                                                                                    |
-| `blogPath`        | `/blog`         | url for the blog post overview page                                                                       |
-| `tagsPath`        | `/tags`         | url for the tags overview page and prefix for tags (e.g. `/tags/my-tag`)                                  |
-| `postsPath`       | `content/posts` | Location of posts                                                                                         |
-| `pagesPath`       | `content/pages` | Location of additional pages (optional)                                                                   |
-| `mdx`             | `true`          | Configure `gatsby-plugin-mdx` (if your website already is using the plugin pass `false` to turn this off) |
-| `formatString`    | `DD.MM.YYYY`    | Configure the date format for Date fields                                                                 |
-| `showLineNumbers` | `true`          | Show line numbers in code blocks                                                                          |
-| `navigation`      | `[]`            | Add links to your internal sites to the left part of the header                                           |
-| `externalLinks`   | `[]`            | Add links to your external sites to the right part of the header                                          |
+| Key               | Default Value                                        | Description                                                                                                |
+| ----------------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `basePath`        | `/`                                                  | Root url for the theme                                                                                     |
+| `blogPath`        | `/blog`                                              | url for the blog post overview page                                                                        |
+| `tagsPath`        | `/tags`                                              | url for the tags overview page and prefix for tags (e.g. `/tags/my-tag`)                                   |
+| `postsPath`       | `content/posts`                                      | Location of posts                                                                                          |
+| `pagesPath`       | `content/pages`                                      | Location of additional pages (optional)                                                                    |
+| `mdx`             | `true`                                               | Configure `gatsby-plugin-mdx` (if your website already is using the plugin pass `false` to turn this off)  |
+| `formatString`    | `DD.MM.YYYY`                                         | Configure the date format for Date fields                                                                  |
+| `showLineNumbers` | `true`                                               | Show line numbers in code blocks                                                                           |
+| `navigation`      | `[]`                                                 | Add links to your internal sites to the left part of the header                                            |
+| `externalLinks`   | `[]`                                                 | Add links to your external sites to the right part of the header                                           |
+| `feed`            | `true`                                               | Configure `gatsby-plugin-feed` (if your website already is using the plugin pass `false` to turn this off) |
+| `feedTitle`       | `Minimal Blog - @lekoarts/gatsby-theme-minimal-blog` | Pass a string to the `title` option of `gatsby-plugin-feed`                                                |
 
 #### Example usage
 

--- a/themes/gatsby-theme-minimal-blog/gatsby-config.js
+++ b/themes/gatsby-theme-minimal-blog/gatsby-config.js
@@ -1,28 +1,32 @@
 const newsletterFeed = require(`./src/utils/newsletterFeed`)
 
-module.exports = options => ({
-  siteMetadata: {
-    siteTitle: `Lupin`,
-    siteTitleAlt: `Minimal Blog - @lekoarts/gatsby-theme-minimal-blog`,
-    siteHeadline: `Minimal Blog - Gatsby Theme from @lekoarts`,
-    siteUrl: `https://minimal-blog.lekoarts.de`,
-    siteDescription: `Typography driven, feature-rich blogging theme with minimal aesthetics. Includes tags/categories support and extensive features for code blocks such as live preview, line numbers, and line highlighting.`,
-    siteLanguage: `en`,
-    siteImage: `/banner.jpg`,
-    author: `@lekoarts_de`,
-  },
-  plugins: [
-    {
-      resolve: `@lekoarts/gatsby-theme-minimal-blog-core`,
-      options,
+module.exports = options => {
+  const { feed = true, feedTitle = `Minimal Blog - @lekoarts/gatsby-theme-minimal-blog` } = options
+
+  return {
+    siteMetadata: {
+      siteTitle: `Lupin`,
+      siteTitleAlt: `Minimal Blog - @lekoarts/gatsby-theme-minimal-blog`,
+      siteHeadline: `Minimal Blog - Gatsby Theme from @lekoarts`,
+      siteUrl: `https://minimal-blog.lekoarts.de`,
+      siteDescription: `Typography driven, feature-rich blogging theme with minimal aesthetics. Includes tags/categories support and extensive features for code blocks such as live preview, line numbers, and line highlighting.`,
+      siteLanguage: `en`,
+      siteImage: `/banner.jpg`,
+      author: `@lekoarts_de`,
     },
-    {
-      resolve: `gatsby-plugin-feed`,
-      options: newsletterFeed,
-    },
-    `gatsby-plugin-react-helmet`,
-    `gatsby-plugin-typescript`,
-    `gatsby-plugin-catch-links`,
-    `gatsby-plugin-theme-ui`,
-  ],
-})
+    plugins: [
+      {
+        resolve: `@lekoarts/gatsby-theme-minimal-blog-core`,
+        options,
+      },
+      feed && {
+        resolve: `gatsby-plugin-feed`,
+        options: newsletterFeed(feedTitle),
+      },
+      `gatsby-plugin-react-helmet`,
+      `gatsby-plugin-typescript`,
+      `gatsby-plugin-catch-links`,
+      `gatsby-plugin-theme-ui`,
+    ],
+  }
+}

--- a/themes/gatsby-theme-minimal-blog/src/utils/newsletterFeed.js
+++ b/themes/gatsby-theme-minimal-blog/src/utils/newsletterFeed.js
@@ -1,6 +1,6 @@
 /* eslint arrow-body-style: 0 */
 
-module.exports = {
+module.exports = title => ({
   query: `
     {
       site {
@@ -8,6 +8,7 @@ module.exports = {
           title: siteTitle
           description: siteDescription
           siteUrl
+          site_url: siteUrl
         }
       }
     }
@@ -40,7 +41,7 @@ module.exports = {
         }
       `,
       output: `rss.xml`,
-      title: `Minimal Blog - @lekoarts/gatsby-theme-minimal-blog`,
+      title,
     },
   ],
-}
+})


### PR DESCRIPTION
Fixes #290

Ideally one could just shadow the file but Gatsby doesn't allow that right now. If you just want to change the title, use `feedTitle`. If you want to use a customized feed, set `feed` to `false` and insert your own options.