### PR TITLE
fix(gatsby-theme-minimal-blog): add Markdown support to gatsby-plugin-mdx

### DIFF
--- a/themes/gatsby-theme-minimal-blog-core/gatsby-config.js
+++ b/themes/gatsby-theme-minimal-blog-core/gatsby-config.js
@@ -23,6 +23,7 @@ module.exports = themeOptions => {
       mdx && {
         resolve: `gatsby-plugin-mdx`,
         options: {
+          extensions: [`.mdx`, `.md`],
           gatsbyRemarkPlugins: [
             {
               resolve: `gatsby-remark-images`,


### PR DESCRIPTION
I added the `.md` extension to the plugin config options :)