### PR TITLE
fix(gatsby-theme-minimal-blog): Add post slug to the url meta tag

### DIFF
--- a/themes/gatsby-theme-minimal-blog/src/components/post.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/post.tsx
@@ -40,6 +40,7 @@ const Post = ({ data: { post } }: PostProps) => (
       title={post.title}
       description={post.description ? post.description : post.excerpt}
       image={post.banner ? post.banner.childImageSharp.resize.src : undefined}
+      pathname={post.slug}
     />
     <Styled.h2>{post.title}</Styled.h2>
     <p sx={{ color: `secondary`, mt: 3, a: { color: `secondary` }, fontSize: [1, 1, 2] }}>


### PR DESCRIPTION
Otherwise, when sharing a post, clicking on the rendered link always directs user to the blog frontpage