### PR TITLE
fix: Remove `@loadable/component`

### DIFF
--- a/themes/gatsby-theme-minimal-blog/package.json
+++ b/themes/gatsby-theme-minimal-blog/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@emotion/core": "^10.0.28",
     "@lekoarts/gatsby-theme-minimal-blog-core": "^2.2.2",
-    "@loadable/component": "^5.12.0",
     "@mdx-js/react": "^1.5.8",
     "@theme-ui/color": "^0.2.53",
     "@theme-ui/components": "^0.2.50",

--- a/themes/gatsby-theme-minimal-blog/src/components/code.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/code.tsx
@@ -1,9 +1,10 @@
 /* eslint react/destructuring-assignment: 0 */
 import React from "react"
-import loadable from "@loadable/component"
+import Highlight, { defaultProps } from "prism-react-renderer"
+import { LiveProvider, LiveEditor, LiveError, LivePreview } from "react-live"
 import theme from "prism-react-renderer/themes/nightOwl"
 import useMinimalBlogConfig from "../hooks/use-minimal-blog-config"
-import { HighlightInnerProps, Language } from "../types"
+import { Language } from "../types"
 
 type CodeProps = {
   codeString: string
@@ -12,25 +13,6 @@ type CodeProps = {
   metastring?: string
   [key: string]: any
 }
-
-const LazyHighlight = loadable(async () => {
-  const Module = await import(`prism-react-renderer`)
-  const Highlight = Module.default
-  const { defaultProps } = Module
-  return (props: any) => <Highlight {...defaultProps} {...props} />
-})
-
-const LazyLiveProvider = loadable(async () => {
-  const Module = await import(`react-live`)
-  const { LiveProvider, LiveEditor, LiveError, LivePreview } = Module
-  return (props: any) => (
-    <LiveProvider {...props}>
-      <LiveEditor data-name="live-editor" />
-      <LiveError />
-      <LivePreview data-name="live-preview" />
-    </LiveProvider>
-  )
-})
 
 function getParams(className = ``) {
   const [lang = ``, params = ``] = className.split(`:`)
@@ -82,11 +64,17 @@ const Code = ({
   const hasLineNumbers = !noLineNumbers && language !== `noLineNumbers` && showLineNumbers
 
   if (props[`react-live`]) {
-    return <LazyLiveProvider code={codeString} noInline theme={theme} />
+    return (
+      <LiveProvider code={codeString} noInline theme={theme}>
+        <LiveEditor data-name="live-editor" />
+        <LiveError />
+        <LivePreview data-name="live-preview" />
+      </LiveProvider>
+    )
   }
   return (
-    <LazyHighlight code={codeString} language={language} theme={theme}>
-      {({ className, style, tokens, getLineProps, getTokenProps }: HighlightInnerProps) => (
+    <Highlight {...defaultProps} code={codeString} language={language} theme={theme}>
+      {({ className, style, tokens, getLineProps, getTokenProps }) => (
         <React.Fragment>
           {title && (
             <div className="code-title">
@@ -115,7 +103,7 @@ const Code = ({
           </div>
         </React.Fragment>
       )}
-    </LazyHighlight>
+    </Highlight>
   )
 }
 

--- a/themes/gatsby-theme-minimal-blog/src/types.d.ts
+++ b/themes/gatsby-theme-minimal-blog/src/types.d.ts
@@ -137,13 +137,3 @@ interface HighlightProps {
   code: string
   children: (props: RenderProps) => React.ReactNode
 }
-
-export interface HighlightInnerProps {
-  className: string
-  style: StyleObj
-  tokens: Token[][]
-  themeDict: ThemeDict
-  getLineProps: (lineInputProps: LineInputProps) => LineOutputProps
-  getStyleForToken: (token: Token) => { [inlineStyle: string]: string }
-  getTokenProps: (tokenInputPropsL: TokenInputProps) => TokenOutputProps
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1384,13 +1384,6 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.7.7":
-  version "7.8.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.0.tgz#8c81711517c56b3d00c6de706b0fb13dc3531549"
-  integrity sha512-Z7ti+HB0puCcLmFE3x90kzaVgbx6TRrYIReaygW6EkBEnJh1ajS4/inhF7CypzWeDV3NFl1AfWj0eMtdihojxw==
-  dependencies:
-    regenerator-runtime "^0.13.2"
-
 "@babel/runtime@^7.8.4":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.4.tgz#d79f5a2040f7caa24d53e563aad49cbc05581308"
@@ -3159,14 +3152,6 @@
   dependencies:
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
-
-"@loadable/component@^5.12.0":
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/@loadable/component/-/component-5.12.0.tgz#34d056d15f53dc08d04e9203cad6867cf4f7306c"
-  integrity sha512-eDG7FPZ8tCFA/mqu2IrYV6eS+UxGBo21PwtEV9QpkpYrx25xKRXzJUm36yfQPK3o7jXu43xpPkwiU4mLWcjJlw==
-  dependencies:
-    "@babel/runtime" "^7.7.7"
-    hoist-non-react-statics "^3.3.1"
 
 "@mdx-js/mdx@^1.3.1":
   version "1.5.5"
@@ -7329,7 +7314,7 @@ cypress@*, cypress@^4.2.0:
     ospath "1.2.2"
     pretty-bytes "5.3.0"
     ramda "0.26.1"
-    request "github:cypress-io/request#b5af0d1fa47eec97ba980cde90a13e69a2afcd16"
+    request cypress-io/request#b5af0d1fa47eec97ba980cde90a13e69a2afcd16
     request-progress "3.0.0"
     supports-color "7.1.0"
     tmp "0.1.0"
@@ -10989,13 +10974,6 @@ hoist-non-react-statics@^3.3.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
-  dependencies:
-    react-is "^16.7.0"
-
-hoist-non-react-statics@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#101685d3aff3b23ea213163f6e8e12f4f111e19f"
-  integrity sha512-wbg3bpgA/ZqWrZuMOeJi8+SKMhr7X9TesL/rXMjTzh0p0JUBo3II8DHboYbuIXWRlttrUFxwcu/5kygrCw8fJw==
   dependencies:
     react-is "^16.7.0"
 
@@ -17889,7 +17867,6 @@ request@^2.44.0, request@^2.83.0, request@^2.87.0, request@^2.88.0:
 
 "request@github:cypress-io/request#b5af0d1fa47eec97ba980cde90a13e69a2afcd16":
   version "2.88.1"
-  uid b5af0d1fa47eec97ba980cde90a13e69a2afcd16
   resolved "https://codeload.github.com/cypress-io/request/tar.gz/b5af0d1fa47eec97ba980cde90a13e69a2afcd16"
   dependencies:
     aws-sign2 "~0.7.0"


### PR DESCRIPTION
Fixes https://github.com/LekoArts/gatsby-themes/issues/299

I initially added it as the bundle was quite bloated but since Gatsby (upstream) changed the chunk strategy a bit and it looks better now. On the flipside it removed the code blocks from the RSS feed.