### PR TITLE
fix: Use withPrefix helper in SEO component

### DIFF
--- a/examples/styleguide/src/components/seo.jsx
+++ b/examples/styleguide/src/components/seo.jsx
@@ -1,5 +1,6 @@
 import React from "react"
 import Helmet from "react-helmet"
+import { withPrefix } from "gatsby"
 import useSiteMetadata from "../hooks/use-site-metadata"
 
 const SEO = ({ title = ``, description = false, pathname = false, image = false, children = null }) => {
@@ -40,9 +41,9 @@ const SEO = ({ title = ``, description = false, pathname = false, image = false,
       <meta name="twitter:image:alt" content={seo.description} />
       <meta name="twitter:creator" content={author} />
       <meta name="gatsby-theme" content="@lekoarts/gatsby-theme-minimal-blog" />
-      <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-      <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-      <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+      <link rel="icon" type="image/png" sizes="32x32" href={withPrefix(`/favicon-32x32.png`)} />
+      <link rel="icon" type="image/png" sizes="16x16" href={withPrefix(`/favicon-16x16.png`)} />
+      <link rel="apple-touch-icon" sizes="180x180" href={withPrefix(`/apple-touch-icon.png`)} />
       {children}
     </Helmet>
   )

--- a/themes/gatsby-theme-cara/src/components/seo.tsx
+++ b/themes/gatsby-theme-cara/src/components/seo.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import Helmet from "react-helmet"
+import { withPrefix } from "gatsby"
 import useSiteMetadata from "../hooks/use-site-metadata"
 
 const defaultProps = {
@@ -56,9 +57,9 @@ const SEO = ({ title, description, pathname, image, children }: Props) => {
       <meta name="twitter:image:alt" content={seo.description} />
       <meta name="twitter:creator" content={author} />
       <meta name="gatsby-theme" content="@lekoarts/gatsby-theme-cara" />
-      <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-      <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-      <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+      <link rel="icon" type="image/png" sizes="32x32" href={withPrefix(`/favicon-32x32.png`)} />
+      <link rel="icon" type="image/png" sizes="16x16" href={withPrefix(`/favicon-16x16.png`)} />
+      <link rel="apple-touch-icon" sizes="180x180" href={withPrefix(`/apple-touch-icon.png`)} />
       {children}
     </Helmet>
   )

--- a/themes/gatsby-theme-emilia/src/components/seo.tsx
+++ b/themes/gatsby-theme-emilia/src/components/seo.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import Helmet from "react-helmet"
+import { withPrefix } from "gatsby"
 import useSiteMetadata from "../hooks/use-site-metadata"
 
 const defaultProps = {
@@ -56,9 +57,9 @@ const SEO = ({ title, description, pathname, image, children }: Props) => {
       <meta name="twitter:image:alt" content={seo.description} />
       <meta name="twitter:creator" content={author} />
       <meta name="gatsby-theme" content="@lekoarts/gatsby-theme-emilia" />
-      <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-      <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-      <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+      <link rel="icon" type="image/png" sizes="32x32" href={withPrefix(`/favicon-32x32.png`)} />
+      <link rel="icon" type="image/png" sizes="16x16" href={withPrefix(`/favicon-16x16.png`)} />
+      <link rel="apple-touch-icon" sizes="180x180" href={withPrefix(`/apple-touch-icon.png`)} />
       {children}
     </Helmet>
   )

--- a/themes/gatsby-theme-emma/src/components/seo.tsx
+++ b/themes/gatsby-theme-emma/src/components/seo.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import Helmet from "react-helmet"
+import { withPrefix } from "gatsby"
 import useSiteMetadata from "../hooks/use-site-metadata"
 
 const defaultProps = {
@@ -56,9 +57,9 @@ const SEO = ({ title, description, pathname, image, children }: Props) => {
       <meta name="twitter:image:alt" content={seo.description} />
       <meta name="twitter:creator" content={author} />
       <meta name="gatsby-theme" content="@lekoarts/gatsby-theme-emma" />
-      <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-      <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-      <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+      <link rel="icon" type="image/png" sizes="32x32" href={withPrefix(`/favicon-32x32.png`)} />
+      <link rel="icon" type="image/png" sizes="16x16" href={withPrefix(`/favicon-16x16.png`)} />
+      <link rel="apple-touch-icon" sizes="180x180" href={withPrefix(`/apple-touch-icon.png`)} />
       {children}
     </Helmet>
   )

--- a/themes/gatsby-theme-graphql-playground/src/components/seo.tsx
+++ b/themes/gatsby-theme-graphql-playground/src/components/seo.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import Helmet from "react-helmet"
+import { withPrefix } from "gatsby"
 import useSiteMetadata from "../hooks/use-site-metadata"
 
 const defaultProps = {
@@ -56,9 +57,9 @@ const SEO = ({ title, description, pathname, image, children }: Props) => {
       <meta name="twitter:image:alt" content={seo.description} />
       <meta name="twitter:creator" content={author} />
       <meta name="gatsby-theme" content="@lekoarts/gatsby-theme-graphql-playground" />
-      <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-      <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-      <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+      <link rel="icon" type="image/png" sizes="32x32" href={withPrefix(`/favicon-32x32.png`)} />
+      <link rel="icon" type="image/png" sizes="16x16" href={withPrefix(`/favicon-16x16.png`)} />
+      <link rel="apple-touch-icon" sizes="180x180" href={withPrefix(`/apple-touch-icon.png`)} />
       {children}
     </Helmet>
   )

--- a/themes/gatsby-theme-minimal-blog/src/components/seo.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/seo.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import Helmet from "react-helmet"
+import { withPrefix } from "gatsby"
 import useSiteMetadata from "../hooks/use-site-metadata"
 
 const defaultProps = {
@@ -56,9 +57,9 @@ const SEO = ({ title, description, pathname, image, children }: Props) => {
       <meta name="twitter:image:alt" content={seo.description} />
       <meta name="twitter:creator" content={author} />
       <meta name="gatsby-theme" content="@lekoarts/gatsby-theme-minimal-blog" />
-      <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-      <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-      <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+      <link rel="icon" type="image/png" sizes="32x32" href={withPrefix(`/favicon-32x32.png`)} />
+      <link rel="icon" type="image/png" sizes="16x16" href={withPrefix(`/favicon-16x16.png`)} />
+      <link rel="apple-touch-icon" sizes="180x180" href={withPrefix(`/apple-touch-icon.png`)} />
       {children}
     </Helmet>
   )


### PR DESCRIPTION
Fixes #335 

This way people don't need to shadow the component when using `gatsby build --prefix-paths`