### PR TITLE
fix: Allow timeToRead to be null

### DIFF
--- a/themes/gatsby-theme-minimal-blog-core/gatsby-node.js
+++ b/themes/gatsby-theme-minimal-blog-core/gatsby-node.js
@@ -76,7 +76,7 @@ exports.createSchemaCustomization = ({ actions, schema }, themeOptions) => {
       excerpt(pruneLength: Int = 160): String!
       body: String!
       html: String
-      timeToRead: Int!
+      timeToRead: Int
       tags: [PostTag]
       banner: File @fileByRelativePath
       description: String
@@ -102,7 +102,7 @@ exports.createSchemaCustomization = ({ actions, schema }, themeOptions) => {
       excerpt(pruneLength: Int = 140): String! @mdxpassthrough(fieldName: "excerpt")
       body: String! @mdxpassthrough(fieldName: "body")
       html: String! @mdxpassthrough(fieldName: "html")
-      timeToRead: Int! @mdxpassthrough(fieldName: "timeToRead")
+      timeToRead: Int @mdxpassthrough(fieldName: "timeToRead")
       tags: [PostTag]
       banner: File @fileByRelativePath
       description: String

--- a/themes/gatsby-theme-minimal-blog/src/components/blog-list-item.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/blog-list-item.tsx
@@ -12,7 +12,7 @@ type BlogListItemProps = {
     date: string
     excerpt: string
     description: string
-    timeToRead: number
+    timeToRead?: number
     tags?: {
       name: string
       slug: string

--- a/themes/gatsby-theme-minimal-blog/src/components/blog.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/blog.tsx
@@ -15,7 +15,7 @@ type PostsProps = {
     date: string
     excerpt: string
     description: string
-    timeToRead: number
+    timeToRead?: number
     tags?: {
       name: string
       slug: string

--- a/themes/gatsby-theme-minimal-blog/src/components/homepage.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/homepage.tsx
@@ -19,7 +19,7 @@ type PostsProps = {
     date: string
     excerpt: string
     description: string
-    timeToRead: number
+    timeToRead?: number
     tags?: {
       name: string
       slug: string

--- a/themes/gatsby-theme-minimal-blog/src/components/listing.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/listing.tsx
@@ -9,7 +9,7 @@ type ListingProps = {
     date: string
     excerpt: string
     description: string
-    timeToRead: number
+    timeToRead?: number
     tags?: {
       name: string
       slug: string

--- a/themes/gatsby-theme-minimal-blog/src/components/post.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/post.tsx
@@ -19,7 +19,7 @@ type PostProps = {
       description?: string
       body: string
       excerpt: string
-      timeToRead: number
+      timeToRead?: number
       banner?: {
         childImageSharp: {
           resize: {
@@ -51,8 +51,8 @@ const Post = ({ data: { post } }: PostProps) => (
           <ItemTags tags={post.tags} />
         </React.Fragment>
       )}
-      {` — `}
-      <span>{post.timeToRead} min read</span>
+      {post.timeToRead && ` — `}
+      {post.timeToRead && <span>{post.timeToRead} min read</span>}
     </p>
     <section sx={{ my: 5, ".gatsby-resp-image-wrapper": { my: [4, 4, 5], boxShadow: shadow.join(`, `) } }}>
       <MDXRenderer>{post.body}</MDXRenderer>

--- a/themes/gatsby-theme-minimal-blog/src/components/tag.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/tag.tsx
@@ -15,7 +15,7 @@ type TagProps = {
     date: string
     excerpt: string
     description: string
-    timeToRead: number
+    timeToRead?: number
     tags: {
       name: string
       slug: string


### PR DESCRIPTION
Fixes #345

The `timeToRead` is handled in `gatsby-plugin-mdx`:
https://github.com/gatsbyjs/gatsby/blob/21d0e5b52121b2516eb97667d185e50796ec7e7b/packages/gatsby-plugin-mdx/gatsby/source-nodes.js#L254-L267

And it seems it has problems parsing only HTML. So I'll make it nullable. If you want the functionality for only HTML one could add a custom resolvers to the field on the `Post` type: https://www.gatsbyjs.org/docs/schema-customization/#createresolvers-api