### PR TITLE
fix(minimal-blog): remove falsy values from plugins list

### DIFF
--- a/themes/gatsby-theme-minimal-blog/gatsby-config.js
+++ b/themes/gatsby-theme-minimal-blog/gatsby-config.js
@@ -27,6 +27,6 @@ module.exports = (options) => {
       `gatsby-plugin-typescript`,
       `gatsby-plugin-catch-links`,
       `gatsby-plugin-theme-ui`,
-    ],
+    ].filter(Boolean),
   }
 }


### PR DESCRIPTION
Currently, build fails when using `feed: false` in `gatsby-config.js` because falsy values are not removed from the `plugins` list. This PR fix this.