### PR TITLE
fix: Split header.tsx into more granular components

### DIFF
--- a/themes/gatsby-theme-minimal-blog/src/components/header-external-links.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/header-external-links.tsx
@@ -1,0 +1,24 @@
+/** @jsx jsx */
+import React from "react"
+import { jsx, Link as TLink } from "theme-ui"
+import useMinimalBlogConfig from "../hooks/use-minimal-blog-config"
+
+const HeaderExternalLinks = () => {
+  const { externalLinks } = useMinimalBlogConfig()
+
+  return (
+    <React.Fragment>
+      {externalLinks && externalLinks.length > 0 && (
+        <div sx={{ "a:not(:first-of-type)": { ml: 3 }, fontSize: [1, `18px`] }}>
+          {externalLinks.map((link) => (
+            <TLink key={link.url} href={link.url}>
+              {link.name}
+            </TLink>
+          ))}
+        </div>
+      )}
+    </React.Fragment>
+  )
+}
+
+export default HeaderExternalLinks

--- a/themes/gatsby-theme-minimal-blog/src/components/header-title.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/header-title.tsx
@@ -1,0 +1,23 @@
+/** @jsx jsx */
+import { Link } from "gatsby"
+import { jsx } from "theme-ui"
+import replaceSlashes from "../utils/replaceSlashes"
+import useSiteMetadata from "../hooks/use-site-metadata"
+import useMinimalBlogConfig from "../hooks/use-minimal-blog-config"
+
+const HeaderTitle = () => {
+  const { siteTitle } = useSiteMetadata()
+  const { basePath } = useMinimalBlogConfig()
+
+  return (
+    <Link
+      to={replaceSlashes(`/${basePath}`)}
+      aria-label={`${siteTitle} - Back to home`}
+      sx={{ color: `heading`, textDecoration: `none` }}
+    >
+      <h1 sx={{ my: 0, fontWeight: `medium`, fontSize: [3, 4] }}>{siteTitle}</h1>
+    </Link>
+  )
+}
+
+export default HeaderTitle

--- a/themes/gatsby-theme-minimal-blog/src/components/header.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/header.tsx
@@ -1,16 +1,14 @@
 /** @jsx jsx */
-import { jsx, useColorMode, Link as TLink } from "theme-ui"
-import { Link } from "gatsby"
+import { jsx, useColorMode } from "theme-ui"
 import { Flex } from "@theme-ui/components"
-import useSiteMetadata from "../hooks/use-site-metadata"
 import useMinimalBlogConfig from "../hooks/use-minimal-blog-config"
 import ColorModeToggle from "./colormode-toggle"
 import Navigation from "./navigation"
-import replaceSlashes from "../utils/replaceSlashes"
+import HeaderTitle from "./header-title"
+import HeaderExternalLinks from "./header-external-links"
 
 const Header = () => {
-  const { siteTitle } = useSiteMetadata()
-  const { navigation: nav, externalLinks, basePath } = useMinimalBlogConfig()
+  const { navigation: nav } = useMinimalBlogConfig()
   const [colorMode, setColorMode] = useColorMode()
   const isDark = colorMode === `dark`
   const toggleColorMode = (e: any) => {
@@ -21,13 +19,7 @@ const Header = () => {
   return (
     <header sx={{ mb: [5, 6] }}>
       <Flex sx={{ alignItems: `center`, justifyContent: `space-between` }}>
-        <Link
-          to={replaceSlashes(`/${basePath}`)}
-          aria-label={`${siteTitle} - Back to home`}
-          sx={{ color: `heading`, textDecoration: `none` }}
-        >
-          <h1 sx={{ my: 0, fontWeight: `medium`, fontSize: [3, 4] }}>{siteTitle}</h1>
-        </Link>
+        <HeaderTitle />
         <ColorModeToggle isDark={isDark} toggle={toggleColorMode} />
       </Flex>
       <div
@@ -44,15 +36,7 @@ const Header = () => {
         }}
       >
         <Navigation nav={nav} />
-        {externalLinks && externalLinks.length > 0 && (
-          <div sx={{ "a:not(:first-of-type)": { ml: 3 }, fontSize: [1, `18px`] }}>
-            {externalLinks.map((link) => (
-              <TLink key={link.url} href={link.url}>
-                {link.name}
-              </TLink>
-            ))}
-          </div>
-        )}
+        <HeaderExternalLinks />
       </div>
     </header>
   )


### PR DESCRIPTION
This will help with issues like https://github.com/LekoArts/gatsby-themes/issues/386 as shadowing is easier now.