### PR TITLE
fix: remove folder creation in onPreBootstrap step

### DIFF
--- a/themes/gatsby-theme-emilia-core/gatsby-node.js
+++ b/themes/gatsby-theme-emilia-core/gatsby-node.js
@@ -1,25 +1,6 @@
-const fs = require(`fs`)
 const kebabCase = require(`lodash.kebabcase`)
-const mkdirp = require(`mkdirp`)
 const path = require(`path`)
 const withDefaults = require(`./utils/default-options`)
-
-// Ensure that content directories exist at site-level
-// If non-existent they'll be created here (as empty folders)
-exports.onPreBootstrap = ({ reporter, store }, themeOptions) => {
-  const { program } = store.getState()
-
-  const { projectsPath } = withDefaults(themeOptions)
-
-  const dirs = [path.join(program.directory, projectsPath)]
-
-  dirs.forEach((dir) => {
-    if (!fs.existsSync(dir)) {
-      reporter.info(`Initializing "${dir}" directory`)
-      mkdirp.sync(dir)
-    }
-  })
-}
 
 const mdxResolverPassthrough = (fieldName) => async (source, args, context, info) => {
   const type = info.schema.getType(`Mdx`)
@@ -163,7 +144,7 @@ exports.sourceNodes = (
 ) => {
   const { createNode } = actions
 
-  const specimensConfig = {
+  const emiliaConfig = {
     name,
     location,
     socialMedia,
@@ -172,14 +153,14 @@ exports.sourceNodes = (
   }
 
   createNode({
-    ...specimensConfig,
+    ...emiliaConfig,
     id: `@lekoarts/gatsby-theme-emilia-core-config`,
     parent: null,
     children: [],
     internal: {
       type: `EmiliaConfig`,
-      contentDigest: createContentDigest(specimensConfig),
-      content: JSON.stringify(specimensConfig),
+      contentDigest: createContentDigest(emiliaConfig),
+      content: JSON.stringify(emiliaConfig),
       description: `Options for @lekoarts/gatsby-theme-emilia-core`,
     },
   })

--- a/themes/gatsby-theme-emma-core/gatsby-node.js
+++ b/themes/gatsby-theme-emma-core/gatsby-node.js
@@ -1,25 +1,5 @@
-const fs = require(`fs`)
 const kebabCase = require(`lodash.kebabcase`)
-const mkdirp = require(`mkdirp`)
-const path = require(`path`)
 const withDefaults = require(`./utils/default-options`)
-
-// Ensure that content directories exist at site-level
-// If non-existent they'll be created here (as empty folders)
-exports.onPreBootstrap = ({ reporter, store }, themeOptions) => {
-  const { program } = store.getState()
-
-  const { projectsPath, pagesPath } = withDefaults(themeOptions)
-
-  const dirs = [path.join(program.directory, projectsPath), path.join(program.directory, pagesPath)]
-
-  dirs.forEach((dir) => {
-    if (!fs.existsSync(dir)) {
-      reporter.info(`Initializing "${dir}" directory`)
-      mkdirp.sync(dir)
-    }
-  })
-}
 
 const mdxResolverPassthrough = (fieldName) => async (source, args, context, info) => {
   const type = info.schema.getType(`Mdx`)

--- a/themes/gatsby-theme-graphql-playground/gatsby-node.js
+++ b/themes/gatsby-theme-graphql-playground/gatsby-node.js
@@ -1,6 +1,6 @@
 const withDefaults = require(`./utils/default-options`)
 
-const mdxResolverPassthrough = (fieldName) => async (source, args, context, info) => {
+const mdxResolverPassthrough = async ({ fieldName, source, args, context, info }) => {
   const type = info.schema.getType(`Mdx`)
   const mdxNode = context.nodeModel.getNodeById({
     id: source.parent,
@@ -24,7 +24,10 @@ exports.createSchemaCustomization = ({ actions }) => {
     },
     extend({ fieldName }) {
       return {
-        resolve: mdxResolverPassthrough(fieldName),
+        async resolve(source, args, context, info) {
+          const result = await mdxResolverPassthrough({ fieldName, source, args, context, info })
+          return result
+        },
       }
     },
   })

--- a/themes/gatsby-theme-minimal-blog-core/gatsby-node.js
+++ b/themes/gatsby-theme-minimal-blog-core/gatsby-node.js
@@ -1,25 +1,5 @@
-const fs = require(`fs`)
 const kebabCase = require(`lodash.kebabcase`)
-const mkdirp = require(`mkdirp`)
-const path = require(`path`)
 const withDefaults = require(`./utils/default-options`)
-
-// Ensure that content directories exist at site-level
-// If non-existent they'll be created here (as empty folders)
-exports.onPreBootstrap = ({ reporter, store }, themeOptions) => {
-  const { program } = store.getState()
-
-  const { postsPath, pagesPath } = withDefaults(themeOptions)
-
-  const dirs = [path.join(program.directory, postsPath), path.join(program.directory, pagesPath)]
-
-  dirs.forEach((dir) => {
-    if (!fs.existsSync(dir)) {
-      reporter.info(`Initializing "${dir}" directory`)
-      mkdirp.sync(dir)
-    }
-  })
-}
 
 const mdxResolverPassthrough = (fieldName) => async (source, args, context, info) => {
   const type = info.schema.getType(`Mdx`)


### PR DESCRIPTION
Creating the folders is a bit unnecessary in hindsight as the data source doesn't always have to be local files. When sourcing from a CMS these folders would be created nevertheless.

So this PR removes that functionality.