### PR TITLE
feat(minimal-blog): Add "Copy" button

### DIFF
--- a/themes/gatsby-theme-minimal-blog-core/gatsby-node.js
+++ b/themes/gatsby-theme-minimal-blog-core/gatsby-node.js
@@ -104,6 +104,7 @@ exports.createSchemaCustomization = ({ actions, schema }, themeOptions) => {
       externalLinks: [ExternalLink]
       navigation: [NavigationEntry]
       showLineNumbers: Boolean
+      showCopyButton: Boolean
     }
     
     type ExternalLink {
@@ -129,6 +130,7 @@ exports.sourceNodes = ({ actions, createContentDigest }, themeOptions) => {
     externalLinks,
     navigation,
     showLineNumbers,
+    showCopyButton,
   } = withDefaults(themeOptions)
 
   const minimalBlogConfig = {
@@ -140,6 +142,7 @@ exports.sourceNodes = ({ actions, createContentDigest }, themeOptions) => {
     externalLinks,
     navigation,
     showLineNumbers,
+    showCopyButton,
   }
 
   createNode({

--- a/themes/gatsby-theme-minimal-blog-core/utils/default-options.js
+++ b/themes/gatsby-theme-minimal-blog-core/utils/default-options.js
@@ -7,6 +7,7 @@ module.exports = (themeOptions) => {
   const externalLinks = themeOptions.externalLinks || []
   const navigation = themeOptions.navigation || []
   const showLineNumbers = themeOptions.showLineNumbers || true
+  const showCopyButton = themeOptions.showCopyButton || true
   const formatString = themeOptions.formatString || `DD.MM.YYYY`
 
   return {
@@ -18,6 +19,7 @@ module.exports = (themeOptions) => {
     externalLinks,
     navigation,
     showLineNumbers,
+    showCopyButton,
     formatString,
   }
 }

--- a/themes/gatsby-theme-minimal-blog/README.md
+++ b/themes/gatsby-theme-minimal-blog/README.md
@@ -74,6 +74,7 @@ gatsby new minimal-blog LekoArts/gatsby-starter-minimal-blog
 | `mdx`             | `true`                                               | Configure `gatsby-plugin-mdx` (if your website already is using the plugin pass `false` to turn this off)  |
 | `formatString`    | `DD.MM.YYYY`                                         | Configure the date format for Date fields                                                                  |
 | `showLineNumbers` | `true`                                               | Show line numbers in code blocks                                                                           |
+| `showCopyButton`  | `true`                                               | Show copy button in code blocks                                                                            |
 | `navigation`      | `[]`                                                 | Add links to your internal sites to the left part of the header                                            |
 | `externalLinks`   | `[]`                                                 | Add links to your external sites to the right part of the header                                           |
 | `feed`            | `true`                                               | Configure `gatsby-plugin-feed` (if your website already is using the plugin pass `false` to turn this off) |

--- a/themes/gatsby-theme-minimal-blog/src/components/code.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/code.tsx
@@ -3,6 +3,8 @@ import React from "react"
 import Highlight, { defaultProps } from "prism-react-renderer"
 import loadable from "@loadable/component"
 import theme from "prism-react-renderer/themes/nightOwl"
+
+import Copy from "./copy"
 import useMinimalBlogConfig from "../hooks/use-minimal-blog-config"
 import { Language } from "../types"
 
@@ -54,6 +56,7 @@ const LazyLiveProvider = loadable(async () => {
   const { LiveProvider, LiveEditor, LiveError, LivePreview } = Module
   return (props: any) => (
     <LiveProvider {...props}>
+      {props.showCopyButton && <Copy content={props.code} />}
       <LiveEditor data-name="live-editor" />
       <LiveError />
       <LivePreview data-name="live-preview" />
@@ -68,7 +71,7 @@ const Code = ({
   metastring = ``,
   ...props
 }: CodeProps) => {
-  const { showLineNumbers } = useMinimalBlogConfig()
+  const { showLineNumbers, showCopyButton } = useMinimalBlogConfig()
 
   const [language, { title = `` }] = getParams(blockClassName)
   const shouldHighlightLine = calculateLinesToHighlight(metastring)
@@ -76,7 +79,11 @@ const Code = ({
   const hasLineNumbers = !noLineNumbers && language !== `noLineNumbers` && showLineNumbers
 
   if (props[`react-live`]) {
-    return <LazyLiveProvider code={codeString} noInline theme={theme} />
+    return (
+      <div className="react-live-wrapper">
+        <LazyLiveProvider code={codeString} noInline theme={theme} showCopyButton={showCopyButton} />
+      </div>
+    )
   }
   return (
     <Highlight {...defaultProps} code={codeString} language={language} theme={theme}>
@@ -89,6 +96,7 @@ const Code = ({
           )}
           <div className="gatsby-highlight" data-language={language}>
             <pre className={className} style={style} data-linenumber={hasLineNumbers}>
+              {showCopyButton && <Copy content={codeString} fileName={title} />}
               {tokens.map((line, i) => {
                 const lineProps = getLineProps({ line, key: i })
 

--- a/themes/gatsby-theme-minimal-blog/src/components/copy.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/copy.tsx
@@ -1,0 +1,48 @@
+/** @jsx jsx */
+import { jsx } from "theme-ui"
+import { useState } from "react"
+
+import copyToClipboard from "../utils/copy-to-clipboard"
+import { visuallyHidden } from "../styles/utils"
+
+const delay = (duration: number) => new Promise((resolve) => setTimeout(resolve, duration))
+
+type CopyProps = {
+  content: string
+  duration?: number
+  fileName?: string
+  trim?: boolean
+}
+
+const Copy = ({ content, duration = 5000, fileName = ``, trim = false }: CopyProps) => {
+  const [copied, setCopied] = useState(false)
+
+  const label = copied
+    ? `${fileName ? `${fileName} ` : ``}copied to clipboard`
+    : `${fileName ? `${fileName}: ` : ``}copy code to clipboard`
+
+  return (
+    <button
+      type="button"
+      name={label}
+      disabled={copied}
+      className="code-copy-button"
+      sx={{
+        variant: `copyButton`,
+      }}
+      onClick={async () => {
+        await copyToClipboard(trim ? content.trim() : content)
+        setCopied(true)
+        await delay(duration)
+        setCopied(false)
+      }}
+    >
+      {copied ? `Copied` : `Copy`}
+      <span sx={{ ...visuallyHidden }} aria-roledescription="status">
+        {label}
+      </span>
+    </button>
+  )
+}
+
+export default Copy

--- a/themes/gatsby-theme-minimal-blog/src/gatsby-plugin-theme-ui/index.js
+++ b/themes/gatsby-theme-minimal-blog/src/gatsby-plugin-theme-ui/index.js
@@ -1,4 +1,5 @@
 import { merge } from "theme-ui"
+import { transparentize } from "@theme-ui/color"
 import { tailwind } from "@theme-ui/presets"
 
 const theme = merge(tailwind, {
@@ -142,6 +143,29 @@ const theme = merge(tailwind, {
       lineHeight: `heading`,
       color: `heading`,
     },
+  },
+  copyButton: {
+    backgroundColor: transparentize(`primary`, 0.8),
+    border: `none`,
+    color: `gray.2`,
+    cursor: `pointer`,
+    fontSize: `16px`,
+    fontFamily: `body`,
+    lineHeight: `solid`,
+    transition: `default`,
+    "&[disabled]": {
+      cursor: `not-allowed`,
+    },
+    ":not([disabled]):hover": {
+      bg: `primary`,
+      color: `white`,
+    },
+    position: `absolute`,
+    top: 0,
+    right: 0,
+    zIndex: 1,
+    borderRadius: `0 0 0 0.25rem`,
+    padding: `0.25rem 0.6rem`,
   },
   dividers: {
     bottom: {

--- a/themes/gatsby-theme-minimal-blog/src/hooks/use-minimal-blog-config.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/hooks/use-minimal-blog-config.tsx
@@ -16,6 +16,7 @@ type UseMinimalBlogConfigProps = {
       slug: string
     }[]
     showLineNumbers: boolean
+    showCopyButton: boolean
   }
 }
 
@@ -37,6 +38,7 @@ const useMinimalBlogConfig = () => {
           slug
         }
         showLineNumbers
+        showCopyButton
       }
     }
   `)

--- a/themes/gatsby-theme-minimal-blog/src/styles/code.ts
+++ b/themes/gatsby-theme-minimal-blog/src/styles/code.ts
@@ -176,6 +176,9 @@ const code = {
     mx: [0, 0, 0, -3],
     fontSize: [1, 1, 2],
   },
+  ".react-live-wrapper .code-copy-button": {
+    right: [0, 0, 0, -3],
+  },
   ".token-line": {
     pr: 3,
   },
@@ -187,6 +190,9 @@ const code = {
       opacity: 0.5,
       left: `-2px`,
     },
+  },
+  ".react-live-wrapper": {
+    position: `relative`,
   },
 }
 

--- a/themes/gatsby-theme-minimal-blog/src/styles/utils.ts
+++ b/themes/gatsby-theme-minimal-blog/src/styles/utils.ts
@@ -1,0 +1,12 @@
+export const visuallyHidden = {
+  // include `px` so we can use it with `sx`
+  border: 0,
+  clip: `rect(0, 0, 0, 0)`,
+  height: `1px`,
+  margin: `-1px`,
+  overflow: `hidden`,
+  padding: 0,
+  position: `absolute`,
+  whiteSpace: `nowrap`,
+  width: `1px`,
+}

--- a/themes/gatsby-theme-minimal-blog/src/utils/copy-to-clipboard.ts
+++ b/themes/gatsby-theme-minimal-blog/src/utils/copy-to-clipboard.ts
@@ -1,0 +1,30 @@
+const copyToClipboard = (str: string) => {
+  const { clipboard } = window.navigator
+  /*
+   * fallback to older browsers (including Safari)
+   * if clipboard API is not supported
+   */
+  if (!clipboard || typeof clipboard.writeText !== `function`) {
+    const textarea = document.createElement(`textarea`)
+    textarea.value = str
+    textarea.setAttribute(`readonly`, `true`)
+    textarea.setAttribute(`contenteditable`, `true`)
+    textarea.style.position = `absolute`
+    textarea.style.left = `-9999px`
+    document.body.appendChild(textarea)
+    textarea.select()
+    const range = document.createRange()
+    const sel = window.getSelection()
+    sel?.removeAllRanges()
+    sel?.addRange(range)
+    textarea.setSelectionRange(0, textarea.value.length)
+    document.execCommand(`copy`)
+    document.body.removeChild(textarea)
+
+    return Promise.resolve(true)
+  }
+
+  return clipboard.writeText(str)
+}
+
+export default copyToClipboard


### PR DESCRIPTION
Adds a "Copy" button to the code blocks of gatsby-theme-minimal-blog.

Fixes #455