### PR TITLE
fix(minimal-blog): Fix code block CSS positioning

### DIFF
--- a/themes/gatsby-theme-minimal-blog-core/utils/default-options.js
+++ b/themes/gatsby-theme-minimal-blog-core/utils/default-options.js
@@ -6,8 +6,8 @@ module.exports = (themeOptions) => {
   const tagsPath = themeOptions.tagsPath || `/tags`
   const externalLinks = themeOptions.externalLinks || []
   const navigation = themeOptions.navigation || []
-  const showLineNumbers = themeOptions.showLineNumbers || true
-  const showCopyButton = themeOptions.showCopyButton || true
+  const showLineNumbers = themeOptions.showLineNumbers !== false
+  const showCopyButton = themeOptions.showCopyButton !== false
   const formatString = themeOptions.formatString || `DD.MM.YYYY`
 
   return {

--- a/themes/gatsby-theme-minimal-blog/src/components/code.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/code.tsx
@@ -97,22 +97,24 @@ const Code = ({
           <div className="gatsby-highlight" data-language={language}>
             <pre className={className} style={style} data-linenumber={hasLineNumbers}>
               {showCopyButton && <Copy content={codeString} fileName={title} />}
-              {tokens.map((line, i) => {
-                const lineProps = getLineProps({ line, key: i })
+              <code className={`language-${language}`}>
+                {tokens.map((line, i) => {
+                  const lineProps = getLineProps({ line, key: i })
 
-                if (shouldHighlightLine(i)) {
-                  lineProps.className = `${lineProps.className} highlight-line`
-                }
+                  if (shouldHighlightLine(i)) {
+                    lineProps.className = `${lineProps.className} highlight-line`
+                  }
 
-                return (
-                  <div {...lineProps}>
-                    {hasLineNumbers && <span className="line-number-style">{i + 1}</span>}
-                    {line.map((token, key) => (
-                      <span {...getTokenProps({ token, key })} />
-                    ))}
-                  </div>
-                )
-              })}
+                  return (
+                    <div {...lineProps}>
+                      {hasLineNumbers && <span className="line-number-style">{i + 1}</span>}
+                      {line.map((token, key) => (
+                        <span {...getTokenProps({ token, key })} />
+                      ))}
+                    </div>
+                  )
+                })}
+              </code>
             </pre>
           </div>
         </React.Fragment>

--- a/themes/gatsby-theme-minimal-blog/src/gatsby-plugin-theme-ui/index.js
+++ b/themes/gatsby-theme-minimal-blog/src/gatsby-plugin-theme-ui/index.js
@@ -149,9 +149,9 @@ const theme = merge(tailwind, {
     border: `none`,
     color: `gray.2`,
     cursor: `pointer`,
-    fontSize: `16px`,
+    fontSize: [`14px`, `14px`, `16px`],
     fontFamily: `body`,
-    lineHeight: `solid`,
+    letterSpacing: `0.025rem`,
     transition: `default`,
     "&[disabled]": {
       cursor: `not-allowed`,

--- a/themes/gatsby-theme-minimal-blog/src/styles/code.ts
+++ b/themes/gatsby-theme-minimal-blog/src/styles/code.ts
@@ -13,17 +13,22 @@ const code = {
   },
   ".prism-code": {
     fontSize: [1, 1, 2],
-    padding: 3,
+    padding: `2rem 1rem 1rem 1rem`,
     webkitOverflowScrolling: `touch`,
     backgroundColor: `transparent`,
-    overflow: `initial`,
-    float: `left`,
     minWidth: `100%`,
     mb: 0,
+    mt: 0,
+    overflow: `auto`,
     '&[data-linenumber="false"]': {
       ".token-line": {
         pl: 3,
       },
+    },
+  },
+  ".gatsby-highlight[data-language=''], .gatsby-highlight[data-language='noLineNumbers']": {
+    ".prism-code": {
+      pt: `1rem`,
     },
   },
   ".token": {
@@ -41,17 +46,15 @@ const code = {
     position: `relative`,
     webkitOverflowScrolling: `touch`,
     bg: `rgb(1, 22, 39)`,
-    overflow: `auto`,
     borderRadius: `2px`,
     mx: [0, 0, 0, -3],
     ".token-line": {
       mx: -3,
+      minWidth: `100%`,
     },
-    "pre.language-": {
-      mt: 0,
-    },
-    "pre.language-noLineNumbers": {
-      mt: 0,
+    "pre code": {
+      float: `left`,
+      minWidth: `100%`,
     },
     'pre[class*="language-"]:before': {
       bg: `white`,
@@ -155,6 +158,16 @@ const code = {
     tabSize: 4,
     hyphens: `none`,
   },
+  ".gatsby-highlight pre::-webkit-scrollbar": {
+    width: 2,
+    height: 2,
+  },
+  ".gatsby-highlight pre::-webkit-scrollbar-thumb": {
+    backgroundColor: `primary`,
+  },
+  ".gatsby-highlight pre::-webkit-scrollbar-track": {
+    background: `rgb(1, 22, 39)`,
+  },
   ".line-number-style": {
     display: `inline-block`,
     width: `3em`,
@@ -176,9 +189,6 @@ const code = {
     mx: [0, 0, 0, -3],
     fontSize: [1, 1, 2],
   },
-  ".react-live-wrapper .code-copy-button": {
-    right: [0, 0, 0, -3],
-  },
   ".token-line": {
     pr: 3,
   },
@@ -193,6 +203,9 @@ const code = {
   },
   ".react-live-wrapper": {
     position: `relative`,
+  },
+  ".react-live-wrapper .code-copy-button": {
+    right: [0, 0, 0, -3],
   },
 }
 


### PR DESCRIPTION
Fixes #479 

- Adds styled scrollbars to code blocks
- Makes language and copy button stick to their positions while horizontally scrolling
- Fix default values for boolean themeOptions
- Adapt padding for code blocks that don't have a code title