### PR TITLE
fix: Pass all page props to page components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -87,6 +87,7 @@ module.exports = {
     "react/forbid-prop-types": 0,
     "react/no-unescaped-entities": 0,
     "react/prop-types": 0,
+    "react/no-unused-prop-types": 0,
     "react/jsx-props-no-spreading": 0,
     "react/jsx-fragments": 0,
     "react/jsx-curly-brace-presence": 0,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -87,7 +87,6 @@ module.exports = {
     "react/forbid-prop-types": 0,
     "react/no-unescaped-entities": 0,
     "react/prop-types": 0,
-    "react/no-unused-prop-types": 0,
     "react/jsx-props-no-spreading": 0,
     "react/jsx-fragments": 0,
     "react/jsx-curly-brace-presence": 0,

--- a/themes/gatsby-theme-emilia/src/@lekoarts/gatsby-theme-emilia-core/components/project.tsx
+++ b/themes/gatsby-theme-emilia/src/@lekoarts/gatsby-theme-emilia-core/components/project.tsx
@@ -11,10 +11,9 @@ type Props = {
     prev: any
     next: any
   }
+  [key: string]: any
 }
 
-export default function EmiliaCoreProject({ data, pageContext }: Props) {
-  const { project, images } = data
-
-  return <Project data={{ ...data, project, images }} pageContext={pageContext} />
+export default function EmiliaCoreProject({ ...props }: Props) {
+  return <Project {...props} />
 }

--- a/themes/gatsby-theme-emilia/src/@lekoarts/gatsby-theme-emilia-core/components/projects.tsx
+++ b/themes/gatsby-theme-emilia/src/@lekoarts/gatsby-theme-emilia-core/components/projects.tsx
@@ -6,10 +6,13 @@ type Props = {
     allProject: any
     [key: string]: string
   }
+  [key: string]: any
 }
 
-export default function EmiliaCoreProjects({ data }: Props) {
-  const { allProject } = data
+export default function EmiliaCoreProjects({ ...props }: Props) {
+  const {
+    data: { allProject },
+  } = props
 
-  return <Projects projects={allProject.nodes} />
+  return <Projects projects={allProject.nodes} {...props} />
 }

--- a/themes/gatsby-theme-emilia/src/components/project.tsx
+++ b/themes/gatsby-theme-emilia/src/components/project.tsx
@@ -54,6 +54,7 @@ type ProjectProps = {
       }
     }
   }
+  [key: string]: any
 }
 
 const Project = ({ data: { project, images }, pageContext: { prev, next } }: ProjectProps) => {

--- a/themes/gatsby-theme-emilia/src/components/projects.tsx
+++ b/themes/gatsby-theme-emilia/src/components/projects.tsx
@@ -28,6 +28,7 @@ type ProjecsStaticQuery = {
       }
     }[]
   }
+  [key: string]: string
 }
 
 const Projects = ({ projects }: Props) => {

--- a/themes/gatsby-theme-emma/src/@lekoarts/gatsby-theme-emma-core/components/page.tsx
+++ b/themes/gatsby-theme-emma/src/@lekoarts/gatsby-theme-emma-core/components/page.tsx
@@ -3,13 +3,12 @@ import Page from "../../../components/page"
 
 type Props = {
   data: {
-    project: any
+    page: any
     [key: string]: any
   }
+  [key: string]: any
 }
 
-export default function EmmaCorePage({ data }: Props) {
-  const { page } = data
-
-  return <Page data={{ ...data, page }} />
+export default function EmmaCorePage({ ...props }: Props) {
+  return <Page {...props} />
 }

--- a/themes/gatsby-theme-emma/src/@lekoarts/gatsby-theme-emma-core/components/project.tsx
+++ b/themes/gatsby-theme-emma/src/@lekoarts/gatsby-theme-emma-core/components/project.tsx
@@ -6,10 +6,9 @@ type Props = {
     project: any
     [key: string]: any
   }
+  [key: string]: any
 }
 
-export default function EmmaCoreProject({ data }: Props) {
-  const { project } = data
-
-  return <Project data={{ ...data, project }} />
+export default function EmmaCoreProject({ ...props }: Props) {
+  return <Project {...props} />
 }

--- a/themes/gatsby-theme-emma/src/@lekoarts/gatsby-theme-emma-core/components/projects.tsx
+++ b/themes/gatsby-theme-emma/src/@lekoarts/gatsby-theme-emma-core/components/projects.tsx
@@ -6,10 +6,13 @@ type Props = {
     allProject: any
     [key: string]: string
   }
+  [key: string]: any
 }
 
-export default function EmmaCoreProjects({ data }: Props) {
-  const { allProject } = data
+export default function EmmaCoreProjects({ ...props }: Props) {
+  const {
+    data: { allProject },
+  } = props
 
-  return <Projects projects={allProject.nodes} />
+  return <Projects projects={allProject.nodes} {...props} />
 }

--- a/themes/gatsby-theme-emma/src/components/page.tsx
+++ b/themes/gatsby-theme-emma/src/components/page.tsx
@@ -17,6 +17,7 @@ type PageProps = {
       cover: ChildImageSharp
     }
   }
+  [key: string]: any
 }
 
 const Page = ({ data: { page } }: PageProps) => {

--- a/themes/gatsby-theme-emma/src/components/project.tsx
+++ b/themes/gatsby-theme-emma/src/components/project.tsx
@@ -22,6 +22,7 @@ type ProjectProps = {
       cover: ChildImageSharp
     }
   }
+  [key: string]: any
 }
 
 const Project = ({ data: { project } }: ProjectProps) => {

--- a/themes/gatsby-theme-emma/src/components/projects.tsx
+++ b/themes/gatsby-theme-emma/src/components/projects.tsx
@@ -14,6 +14,7 @@ type ProjectsProps = {
     client: string
     cover: ChildImageSharp
   }[]
+  [key: string]: any
 }
 
 const Projects = ({ projects }: ProjectsProps) => {

--- a/themes/gatsby-theme-minimal-blog/src/@lekoarts/gatsby-theme-minimal-blog-core/components/blog.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/@lekoarts/gatsby-theme-minimal-blog-core/components/blog.tsx
@@ -6,10 +6,13 @@ type Props = {
     allPost: any
     [key: string]: string
   }
+  [key: string]: any
 }
 
-export default function MinimalBlogCoreBlog({ data }: Props) {
-  const { allPost } = data
+export default function MinimalBlogCoreBlog({ ...props }: Props) {
+  const {
+    data: { allPost },
+  } = props
 
-  return <Blog posts={allPost.nodes} />
+  return <Blog posts={allPost.nodes} {...props} />
 }

--- a/themes/gatsby-theme-minimal-blog/src/@lekoarts/gatsby-theme-minimal-blog-core/components/homepage.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/@lekoarts/gatsby-theme-minimal-blog-core/components/homepage.tsx
@@ -6,10 +6,13 @@ type Props = {
     allPost: any
     [key: string]: string
   }
+  [key: string]: any
 }
 
-export default function MinimalBlogCoreHomepage({ data }: Props) {
-  const { allPost } = data
+export default function MinimalBlogCoreHomepage({ ...props }: Props) {
+  const {
+    data: { allPost },
+  } = props
 
-  return <Homepage posts={allPost.nodes} />
+  return <Homepage posts={allPost.nodes} {...props} />
 }

--- a/themes/gatsby-theme-minimal-blog/src/@lekoarts/gatsby-theme-minimal-blog-core/components/page.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/@lekoarts/gatsby-theme-minimal-blog-core/components/page.tsx
@@ -6,10 +6,9 @@ type Props = {
     page: any
     [key: string]: any
   }
+  [key: string]: any
 }
 
-export default function MinimalBlogCorePage({ data }: Props) {
-  const { page } = data
-
-  return <Page data={{ ...data, page }} />
+export default function MinimalBlogCorePage({ ...props }: Props) {
+  return <Page {...props} />
 }

--- a/themes/gatsby-theme-minimal-blog/src/@lekoarts/gatsby-theme-minimal-blog-core/components/post.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/@lekoarts/gatsby-theme-minimal-blog-core/components/post.tsx
@@ -6,10 +6,9 @@ type Props = {
     post: any
     [key: string]: any
   }
+  [key: string]: any
 }
 
-export default function MinimalBlogCorePost({ data }: Props) {
-  const { post } = data
-
-  return <Post data={{ ...data, post }} />
+export default function MinimalBlogCorePost({ ...props }: Props) {
+  return <Post {...props} />
 }

--- a/themes/gatsby-theme-minimal-blog/src/@lekoarts/gatsby-theme-minimal-blog-core/components/tag.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/@lekoarts/gatsby-theme-minimal-blog-core/components/tag.tsx
@@ -6,11 +6,19 @@ type Props = {
     allPost: any
     [key: string]: any
   }
-  pageContext: any
+  pageContext: {
+    isCreatedByStatefulCreatePages: boolean
+    slug: string
+    name: string
+    [key: string]: any
+  }
+  [key: string]: any
 }
 
-export default function MinimalBlogCoreTag({ data, pageContext }: Props) {
-  const { allPost } = data
+export default function MinimalBlogCoreTag({ ...props }: Props) {
+  const {
+    data: { allPost },
+  } = props
 
-  return <Tag posts={allPost.nodes} pageContext={pageContext} />
+  return <Tag posts={allPost.nodes} {...props} />
 }

--- a/themes/gatsby-theme-minimal-blog/src/@lekoarts/gatsby-theme-minimal-blog-core/components/tags.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/@lekoarts/gatsby-theme-minimal-blog-core/components/tags.tsx
@@ -10,10 +10,13 @@ type Props = {
       }[]
     }
   }
+  [key: string]: any
 }
 
-export default function MinimalBlogCoreTags({ data }: Props) {
-  const { allPost } = data
+export default function MinimalBlogCoreTags({ ...props }: Props) {
+  const {
+    data: { allPost },
+  } = props
 
-  return <Tags list={allPost.group} />
+  return <Tags list={allPost.group} {...props} />
 }

--- a/themes/gatsby-theme-minimal-blog/src/components/blog.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/blog.tsx
@@ -21,6 +21,7 @@ type PostsProps = {
       slug: string
     }[]
   }[]
+  [key: string]: any
 }
 
 const Blog = ({ posts }: PostsProps) => {

--- a/themes/gatsby-theme-minimal-blog/src/components/homepage.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/homepage.tsx
@@ -25,6 +25,7 @@ type PostsProps = {
       slug: string
     }[]
   }[]
+  [key: string]: any
 }
 
 const Homepage = ({ posts }: PostsProps) => {

--- a/themes/gatsby-theme-minimal-blog/src/components/page.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/page.tsx
@@ -13,6 +13,7 @@ type PageProps = {
       body: string
     }
   }
+  [key: string]: any
 }
 
 const Page = ({ data: { page } }: PageProps) => (


### PR DESCRIPTION
Fixes https://github.com/LekoArts/gatsby-themes/issues/483

I wasn't passing all page properties along to the components that the user is supposed to shadow thus leaving out things like e.g. `pageContext`. I now spread all props on the components, leaving the previous props like `posts` for example in tact as that would be a breaking change.

The TS types are a mess for this but I'll fix that in a follow-up PR.

Everything should still behave the same, only all props should be forwarded now.