### PR TITLE
fix(gatsby-theme-minimal-blog): Use correct h1 on all pages

### DIFF
--- a/cypress/e2e/minimal-blog.ts
+++ b/cypress/e2e/minimal-blog.ts
@@ -83,7 +83,7 @@ describe(`gatsby-theme-minimal-blog`, () => {
       .click()
       .waitForRouteChange()
       .assertRoute(`/introduction-to-defence-against-the-dark-arts`)
-      .get(`h2`)
+      .get(`h1`)
       .within(() => {
         cy.findByText(/Introduction to "Defence against the Dark Arts"/i)
       })

--- a/cypress/e2e/minimal-blog.ts
+++ b/cypress/e2e/minimal-blog.ts
@@ -22,7 +22,7 @@ describe(`gatsby-theme-minimal-blog`, () => {
     })
     cy.waitForRouteChange()
       .assertRoute(`/blog`)
-      .get(`h2`)
+      .get(`h1`)
       .within(() => {
         cy.findByText(/Blog/i)
       })
@@ -35,7 +35,7 @@ describe(`gatsby-theme-minimal-blog`, () => {
       .click()
       .waitForRouteChange()
       .assertRoute(`/tags/tutorial`)
-      .get(`h2`)
+      .get(`h1`)
       .within(() => {
         cy.findByText(/Tutorial/i)
       })
@@ -47,7 +47,7 @@ describe(`gatsby-theme-minimal-blog`, () => {
       .click()
       .waitForRouteChange()
       .assertRoute(`/tags`)
-      .get(`h2`)
+      .get(`h1`)
       .within(() => {
         cy.findByText(/Tags/i)
       })

--- a/themes/gatsby-theme-minimal-blog/src/components/blog.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/blog.tsx
@@ -31,8 +31,14 @@ const Blog = ({ posts }: PostsProps) => {
     <Layout>
       <SEO title="Blog" />
       <Flex sx={{ alignItems: `center`, justifyContent: `space-between`, flexFlow: `wrap` }}>
-        <Heading variant="styles.h2">Blog</Heading>
-        <TLink as={Link} sx={{ variant: `links.secondary` }} to={replaceSlashes(`/${basePath}/${tagsPath}`)}>
+        <Heading as="h1" variant="styles.h1" sx={{ marginY: 2 }}>
+          Blog
+        </Heading>
+        <TLink
+          as={Link}
+          sx={{ variant: `links.secondary`, marginY: 2 }}
+          to={replaceSlashes(`/${basePath}/${tagsPath}`)}
+        >
           View all tags
         </TLink>
       </Flex>

--- a/themes/gatsby-theme-minimal-blog/src/components/header-title.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/header-title.tsx
@@ -15,7 +15,7 @@ const HeaderTitle = () => {
       aria-label={`${siteTitle} - Back to home`}
       sx={{ color: `heading`, textDecoration: `none` }}
     >
-      <h1 sx={{ my: 0, fontWeight: `medium`, fontSize: [3, 4] }}>{siteTitle}</h1>
+      <div sx={{ my: 0, fontWeight: `medium`, fontSize: [3, 4] }}>{siteTitle}</div>
     </Link>
   )
 }

--- a/themes/gatsby-theme-minimal-blog/src/components/homepage.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/homepage.tsx
@@ -6,7 +6,9 @@ import Title from "./title"
 import Listing from "./listing"
 import List from "./list"
 import useMinimalBlogConfig from "../hooks/use-minimal-blog-config"
+import useSiteMetadata from "../hooks/use-site-metadata"
 import replaceSlashes from "../utils/replaceSlashes"
+import { visuallyHidden } from "../styles/utils"
 // @ts-ignore
 import Hero from "../texts/hero"
 // @ts-ignore
@@ -30,9 +32,11 @@ type PostsProps = {
 
 const Homepage = ({ posts }: PostsProps) => {
   const { basePath, blogPath } = useMinimalBlogConfig()
+  const { siteTitle } = useSiteMetadata()
 
   return (
     <Layout>
+      <h1 sx={visuallyHidden}>{siteTitle}</h1>
       <section sx={{ mb: [5, 6, 7], p: { fontSize: [1, 2, 3], mt: 2 } }}>
         <Hero />
       </section>

--- a/themes/gatsby-theme-minimal-blog/src/components/page.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/page.tsx
@@ -19,7 +19,9 @@ type PageProps = {
 const Page = ({ data: { page } }: PageProps) => (
   <Layout>
     <SEO title={page.title} description={page.excerpt} />
-    <Heading variant="styles.h2">{page.title}</Heading>
+    <Heading as="h1" variant="styles.h1">
+      {page.title}
+    </Heading>
     <section sx={{ my: 5, variant: `layout.content` }}>
       <MDXRenderer>{page.body}</MDXRenderer>
     </section>

--- a/themes/gatsby-theme-minimal-blog/src/components/post.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/post.tsx
@@ -44,7 +44,9 @@ const Post = ({ data: { post } }: PostProps) => (
       pathname={post.slug}
       canonicalUrl={post.canonicalUrl}
     />
-    <Heading as="h1" variant="styles.h2">{post.title}</Heading>
+    <Heading as="h1" variant="styles.h2">
+      {post.title}
+    </Heading>
     <p sx={{ color: `secondary`, mt: 3, a: { color: `secondary` }, fontSize: [1, 1, 2] }}>
       <time>{post.date}</time>
       {post.tags && (

--- a/themes/gatsby-theme-minimal-blog/src/components/post.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/post.tsx
@@ -44,7 +44,7 @@ const Post = ({ data: { post } }: PostProps) => (
       pathname={post.slug}
       canonicalUrl={post.canonicalUrl}
     />
-    <Heading variant="styles.h2">{post.title}</Heading>
+    <Heading as="h1" variant="styles.h2">{post.title}</Heading>
     <p sx={{ color: `secondary`, mt: 3, a: { color: `secondary` }, fontSize: [1, 1, 2] }}>
       <time>{post.date}</time>
       {post.tags && (

--- a/themes/gatsby-theme-minimal-blog/src/components/post.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/post.tsx
@@ -44,7 +44,7 @@ const Post = ({ data: { post } }: PostProps) => (
       pathname={post.slug}
       canonicalUrl={post.canonicalUrl}
     />
-    <Heading as="h1" variant="styles.h2">
+    <Heading as="h1" variant="styles.h1">
       {post.title}
     </Heading>
     <p sx={{ color: `secondary`, mt: 3, a: { color: `secondary` }, fontSize: [1, 1, 2] }}>

--- a/themes/gatsby-theme-minimal-blog/src/components/tag.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/tag.tsx
@@ -36,8 +36,14 @@ const Tag = ({ posts, pageContext }: TagProps) => {
     <Layout>
       <SEO title={`Tag: ${pageContext.name}`} />
       <Flex sx={{ alignItems: `center`, justifyContent: `space-between`, flexFlow: `wrap` }}>
-        <Heading variant="styles.h2">{pageContext.name}</Heading>
-        <TLink as={Link} sx={{ variant: `links.secondary` }} to={replaceSlashes(`/${basePath}/${tagsPath}`)}>
+        <Heading as="h1" variant="styles.h1" sx={{ marginY: 2 }}>
+          {pageContext.name}
+        </Heading>
+        <TLink
+          as={Link}
+          sx={{ variant: `links.secondary`, marginY: 2 }}
+          to={replaceSlashes(`/${basePath}/${tagsPath}`)}
+        >
           View all tags
         </TLink>
       </Flex>

--- a/themes/gatsby-theme-minimal-blog/src/components/tags.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/tags.tsx
@@ -21,7 +21,9 @@ const Tags = ({ list }: PostsProps) => {
   return (
     <Layout>
       <SEO title="Tags" />
-      <Heading variant="styles.h2">Tags</Heading>
+      <Heading as="h1" variant="styles.h1">
+        Tags
+      </Heading>
       <Box mt={[4, 5]}>
         {list.map((listItem) => (
           <Flex key={listItem.fieldValue} mb={[1, 1, 2]} sx={{ alignItems: `center` }}>

--- a/themes/gatsby-theme-minimal-blog/src/gatsby-plugin-theme-ui/index.js
+++ b/themes/gatsby-theme-minimal-blog/src/gatsby-plugin-theme-ui/index.js
@@ -66,27 +66,27 @@ const theme = merge(tailwind, {
     },
     h1: {
       variant: `text.heading`,
-      fontSize: [5, 6, 7],
+      fontSize: [5, 6, 6, 7],
       mt: 4,
     },
     h2: {
       variant: `text.heading`,
-      fontSize: [4, 5, 6],
+      fontSize: [4, 5, 5, 6],
       mt: 4,
     },
     h3: {
       variant: `text.heading`,
-      fontSize: [3, 4, 5],
+      fontSize: [3, 4, 4, 5],
       mt: 4,
     },
     h4: {
       variant: `text.heading`,
-      fontSize: [2, 3, 4],
+      fontSize: [2, 3, 3, 4],
       mt: 3,
     },
     h5: {
       variant: `text.heading`,
-      fontSize: [1, 2, 3],
+      fontSize: [1, 2, 2, 3],
       mt: 3,
     },
     h6: {


### PR DESCRIPTION
From an SEO perspective it makes sense for the post title to be an H1 tag. No change to visual styling.