### PR TITLE
fix(gatsby-theme-minimal-blog): Add additional language PHP & PY flags

### DIFF
--- a/themes/gatsby-theme-minimal-blog/src/styles/code.ts
+++ b/themes/gatsby-theme-minimal-blog/src/styles/code.ts
@@ -118,6 +118,16 @@ const code = {
       background: `#f9ac00`,
       color: `black`,
     },
+    'pre[class~="language-php"]:before': {
+      content: `"php"`,
+      background: `#777bb3`,
+      color: `black`,
+    },
+    'pre[class~="language-py"]:before, pre[class~="language-python"]:before': {
+      content: `"py"`,
+      background: `#306998`,
+      color: `white`,
+    },
     'pre[class~="language-text"]:before': {
       content: `"text"`,
     },


### PR DESCRIPTION
# Description

- This PR is motivated by #514 - the intention is to add additional language flags for _gatsby-starter-minimal-blog_

# Details

- Languages added: PHP, Python
- Both flags have color contrasts of AA 
- Colors were chosen from the official colors of the language
- Languages were chosen by looking at a ranking of most commonly used in 2020

Resolves #514 