### PR TITLE
fix(jodie): Instagram - Match min px to match iphone 5s screen

### DIFF
--- a/examples/jodie/src/components/style.css
+++ b/examples/jodie/src/components/style.css
@@ -1,6 +1,6 @@
 .instagram-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(450px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
 }
 
 .instagram-overlay {


### PR DESCRIPTION
That is to prevent horizontal scrolling on smaller screens
as discussed here 

Fixes #548 