### PR TITLE
fix: email example

### DIFF
--- a/themes/gatsby-theme-cara/src/sections/contact.mdx
+++ b/themes/gatsby-theme-cara/src/sections/contact.mdx
@@ -1,3 +1,3 @@
 ## Get in touch
 
-Say [Hi](plizNoSp4m@domain.tld) or find me on other platforms: [Dribbble](https://dribbble.com/LekoArts) & [Instagram](https://www.instagram.com/lekoarts.de/)
+Say [Hi](mailto:plizNoSp4m@domain.tld) or find me on other platforms: [Dribbble](https://dribbble.com/LekoArts) & [Instagram](https://www.instagram.com/lekoarts.de/)


### PR DESCRIPTION
Fixed the example of linking to email under the "Get in touch" section of the theme [@lekoarts/gatsby-theme-cara](https://github.com/LekoArts/gatsby-themes/tree/master/themes/gatsby-theme-cara). Now the link can be correctly opened.