### PR TITLE
Minimal Blog: Initialize color scheme based on preferred color scheme

### DIFF
--- a/themes/gatsby-theme-minimal-blog/src/gatsby-plugin-theme-ui/index.js
+++ b/themes/gatsby-theme-minimal-blog/src/gatsby-plugin-theme-ui/index.js
@@ -5,6 +5,7 @@ import { tailwind } from "@theme-ui/presets"
 const theme = merge(tailwind, {
   initialColorModeName: `light`,
   useCustomProperties: true,
+  useColorSchemeMediaQuery: true,
   colors: {
     primary: tailwind.colors.purple[7],
     secondary: `#5f6c80`,


### PR DESCRIPTION
Switch color scheme based on users preferred color scheme (via color scheme media query).

Alternatively you could point out how to do this in the README.