### PR TITLE
Emilia Theme Visual Bug Fix: long links can overflow past page's border.

### DIFF
--- a/themes/gatsby-theme-emilia/src/components/header-project.tsx
+++ b/themes/gatsby-theme-emilia/src/components/header-project.tsx
@@ -102,7 +102,7 @@ const HeaderProject = ({ title, areas, description = ``, date }: HeaderProjectPr
               ))}
             </div>
             {description && (
-              <div sx={{ maxWidth: `900px`, mx: `auto`, mt: 5, p: { textAlign: `left` } }}>
+              <div sx={{ maxWidth: `900px`, mx: `auto`, mt: 5, p: { textAlign: `left`, overflowWrap: `break-word` } }}>
                 <MDXRenderer>{description}</MDXRenderer>
               </div>
             )}


### PR DESCRIPTION
For descriptions of an emilia theme's project page, long links could over flow and move way past the screen. Added overflow-wrap attribute to patch this visual bug. One line change to header-project.tsx file.