### PR TITLE
chore: Update starter READMEs

### DIFF
--- a/examples/cara/README.md
+++ b/examples/cara/README.md
@@ -38,24 +38,26 @@ Also be sure to check out other [Free & Open Source Gatsby Themes](https://theme
 
 [<img src="https://www.gatsbyjs.com/deploynow.svg" alt="Deploy to Gatsby Cloud">](https://www.gatsbyjs.com/dashboard/deploynow?url=https://github.com/LekoArts/gatsby-starter-portfolio-cara)
 
-1. **Create a Gatsby site.**
+### 1. **Create a Gatsby site.**
 
-Use the Gatsby CLI to create a new site, specifying this project
-
-```sh
-gatsby new project-name https://github.com/LekoArts/gatsby-starter-portfolio-cara
-```
-
-2. **Start developing.**
-
-Navigate into your new site's directory and start it up.
+Use `git` to clone the site and navigate into it:
 
 ```sh
+git clone https://github.com/LekoArts/gatsby-starter-portfolio-cara project-name
 cd project-name
-gatsby develop
 ```
 
-3. **Open the code and start customizing!**
+### 2. **Install dependencies.**
+
+If you use npm 7 or above use the `--legacy-peer-deps` flag. If you use npm 6 you can use `npm install`.
+
+```sh
+npm install --legacy-peer-deps
+```
+
+### 3. **Open the code and start customizing!**
+
+Start the site by running `npm run develop`.
 
 Your site is now running at `http://localhost:8000`!
 

--- a/examples/cara/gatsby-config.js
+++ b/examples/cara/gatsby-config.js
@@ -10,9 +10,6 @@ module.exports = {
     // See all options: https://github.com/LekoArts/gatsby-themes/blob/master/themes/gatsby-theme-cara/gatsby-config.js
     siteTitleAlt: `Cara - Gatsby Starter Portfolio`,
   },
-  flags: {
-    FAST_DEV: true,
-  },
   plugins: [
     {
       resolve: `@lekoarts/gatsby-theme-cara`,

--- a/examples/emilia/README.md
+++ b/examples/emilia/README.md
@@ -43,24 +43,26 @@ Also be sure to check out other [Free & Open Source Gatsby Themes](https://theme
 
 [<img src="https://www.gatsbyjs.com/deploynow.svg" alt="Deploy to Gatsby Cloud">](https://www.gatsbyjs.com/dashboard/deploynow?url=https://github.com/LekoArts/gatsby-starter-portfolio-emilia)
 
-1. **Create a Gatsby site.**
+### 1. **Create a Gatsby site.**
 
-Use the Gatsby CLI to create a new site, specifying this project
-
-```sh
-gatsby new project-name https://github.com/LekoArts/gatsby-starter-portfolio-emilia
-```
-
-2. **Start developing.**
-
-Navigate into your new site's directory and start it up.
+Use `git` to clone the site and navigate into it:
 
 ```sh
+git clone https://github.com/LekoArts/gatsby-starter-portfolio-emilia project-name
 cd project-name
-gatsby develop
 ```
 
-3. **Open the code and start customizing!**
+### 2. **Install dependencies.**
+
+If you use npm 7 or above use the `--legacy-peer-deps` flag. If you use npm 6 you can use `npm install`.
+
+```sh
+npm install --legacy-peer-deps
+```
+
+### 3. **Open the code and start customizing!**
+
+Start the site by running `npm run develop`.
 
 Your site is now running at `http://localhost:8000`!
 

--- a/examples/emilia/gatsby-config.js
+++ b/examples/emilia/gatsby-config.js
@@ -7,9 +7,6 @@ module.exports = {
   siteMetadata: {
     siteTitleAlt: `Emilia - Gatsby Starter Portfolio`,
   },
-  flags: {
-    FAST_DEV: true,
-  },
   plugins: [
     {
       resolve: `@lekoarts/gatsby-theme-emilia`,

--- a/examples/emma/README.md
+++ b/examples/emma/README.md
@@ -43,24 +43,26 @@ Also be sure to check out other [Free & Open Source Gatsby Themes](https://theme
 
 [<img src="https://www.gatsbyjs.com/deploynow.svg" alt="Deploy to Gatsby Cloud">](https://www.gatsbyjs.com/dashboard/deploynow?url=https://github.com/LekoArts/gatsby-starter-portfolio-emma)
 
-1. **Create a Gatsby site.**
+### 1. **Create a Gatsby site.**
 
-Use the Gatsby CLI to create a new site, specifying this project
-
-```sh
-gatsby new project-name https://github.com/LekoArts/gatsby-starter-portfolio-emma
-```
-
-2. **Start developing.**
-
-Navigate into your new site's directory and start it up.
+Use `git` to clone the site and navigate into it:
 
 ```sh
+git clone https://github.com/LekoArts/gatsby-starter-portfolio-emma project-name
 cd project-name
-gatsby develop
 ```
 
-3. **Open the code and start customizing!**
+### 2. **Install dependencies.**
+
+If you use npm 7 or above use the `--legacy-peer-deps` flag. If you use npm 6 you can use `npm install`.
+
+```sh
+npm install --legacy-peer-deps
+```
+
+### 3. **Open the code and start customizing!**
+
+Start the site by running `npm run develop`.
 
 Your site is now running at `http://localhost:8000`!
 

--- a/examples/emma/gatsby-config.js
+++ b/examples/emma/gatsby-config.js
@@ -7,9 +7,6 @@ module.exports = {
   siteMetadata: {
     siteTitleAlt: `Emma - Gatsby Starter Portfolio`,
   },
-  flags: {
-    FAST_DEV: true,
-  },
   plugins: [
     {
       resolve: `@lekoarts/gatsby-theme-emma`,

--- a/examples/graphql-playground/README.md
+++ b/examples/graphql-playground/README.md
@@ -39,24 +39,26 @@ Also be sure to check out other [Free & Open Source Gatsby Themes](https://theme
 
 [<img src="https://www.gatsbyjs.com/deploynow.svg" alt="Deploy to Gatsby Cloud">](https://www.gatsbyjs.com/dashboard/deploynow?url=https://github.com/LekoArts/gatsby-starter-graphql-playground)
 
-1. **Create a Gatsby site.**
+### 1. **Create a Gatsby site.**
 
-Use the Gatsby CLI to create a new site, specifying this project
-
-```sh
-gatsby new project-name https://github.com/LekoArts/gatsby-starter-graphql-playground
-```
-
-2. **Start developing.**
-
-Navigate into your new site's directory and start it up.
+Use `git` to clone the site and navigate into it:
 
 ```sh
+git clone https://github.com/LekoArts/gatsby-starter-graphql-playground project-name
 cd project-name
-gatsby develop
 ```
 
-3. **Open the code and start customizing!**
+### 2. **Install dependencies.**
+
+If you use npm 7 or above use the `--legacy-peer-deps` flag. If you use npm 6 you can use `npm install`.
+
+```sh
+npm install --legacy-peer-deps
+```
+
+### 3. **Open the code and start customizing!**
+
+Start the site by running `npm run develop`.
 
 Your site is now running at `http://localhost:8000`!
 

--- a/examples/graphql-playground/gatsby-config.js
+++ b/examples/graphql-playground/gatsby-config.js
@@ -3,9 +3,6 @@ require(`dotenv`).config()
 const shouldAnalyseBundle = process.env.ANALYSE_BUNDLE
 
 module.exports = {
-  flags: {
-    FAST_DEV: true,
-  },
   plugins: [
     {
       resolve: `@lekoarts/gatsby-theme-graphql-playground`,

--- a/examples/jodie/README.md
+++ b/examples/jodie/README.md
@@ -43,24 +43,26 @@ Also be sure to check out other [Free & Open Source Gatsby Themes](https://theme
 
 [<img src="https://www.gatsbyjs.com/deploynow.svg" alt="Deploy to Gatsby Cloud">](https://www.gatsbyjs.com/dashboard/deploynow?url=https://github.com/LekoArts/gatsby-starter-portfolio-jodie)
 
-1. **Create a Gatsby site.**
+### 1. **Create a Gatsby site.**
 
-Use the Gatsby CLI to create a new site, specifying this project
-
-```sh
-gatsby new project-name https://github.com/LekoArts/gatsby-starter-portfolio-jodie
-```
-
-2. **Start developing.**
-
-Navigate into your new site's directory and start it up.
+Use `git` to clone the site and navigate into it:
 
 ```sh
+git clone https://github.com/LekoArts/gatsby-starter-portfolio-jodie project-name
 cd project-name
-gatsby develop
 ```
 
-3. **Open the code and start customizing!**
+### 2. **Install dependencies.**
+
+If you use npm 7 or above use the `--legacy-peer-deps` flag. If you use npm 6 you can use `npm install`.
+
+```sh
+npm install --legacy-peer-deps
+```
+
+### 3. **Open the code and start customizing!**
+
+Start the site by running `npm run develop`.
 
 Your site is now running at `http://localhost:8000`!
 

--- a/examples/jodie/gatsby-config.js
+++ b/examples/jodie/gatsby-config.js
@@ -7,9 +7,6 @@ module.exports = {
   siteMetadata: {
     siteTitleAlt: `Jodie - Gatsby Starter Portfolio`,
   },
-  flags: {
-    FAST_DEV: true,
-  },
   plugins: [
     {
       resolve: `@lekoarts/gatsby-theme-jodie`,

--- a/examples/minimal-blog/README.md
+++ b/examples/minimal-blog/README.md
@@ -45,24 +45,26 @@ Also be sure to check out other [Free & Open Source Gatsby Themes](https://theme
 
 [<img src="https://www.gatsbyjs.com/deploynow.svg" alt="Deploy to Gatsby Cloud">](https://www.gatsbyjs.com/dashboard/deploynow?url=https://github.com/LekoArts/gatsby-starter-minimal-blog)
 
-1. **Create a Gatsby site.**
+### 1. **Create a Gatsby site.**
 
-Use the Gatsby CLI to create a new site, specifying this project
-
-```sh
-gatsby new project-name https://github.com/LekoArts/gatsby-starter-minimal-blog
-```
-
-2. **Start developing.**
-
-Navigate into your new site's directory and start it up.
+Use `git` to clone the site and navigate into it:
 
 ```sh
+git clone https://github.com/LekoArts/gatsby-starter-minimal-blog project-name
 cd project-name
-gatsby develop
 ```
 
-3. **Open the code and start customizing!**
+### 2. **Install dependencies.**
+
+If you use npm 7 or above use the `--legacy-peer-deps` flag. If you use npm 6 you can use `npm install`.
+
+```sh
+npm install --legacy-peer-deps
+```
+
+### 3. **Open the code and start customizing!**
+
+Start the site by running `npm run develop`.
 
 Your site is now running at `http://localhost:8000`!
 

--- a/examples/minimal-blog/gatsby-config.js
+++ b/examples/minimal-blog/gatsby-config.js
@@ -7,9 +7,6 @@ module.exports = {
   siteMetadata: {
     siteTitleAlt: `Minimal Blog - Gatsby Theme`,
   },
-  flags: {
-    FAST_DEV: true,
-  },
   plugins: [
     {
       resolve: `@lekoarts/gatsby-theme-minimal-blog`,

--- a/examples/specimens/README.md
+++ b/examples/specimens/README.md
@@ -44,24 +44,26 @@ Also be sure to check out other [Free & Open Source Gatsby Themes](https://theme
 
 [<img src="https://www.gatsbyjs.com/deploynow.svg" alt="Deploy to Gatsby Cloud">](https://www.gatsbyjs.com/dashboard/deploynow?url=https://github.com/LekoArts/gatsby-starter-specimens)
 
-1. **Create a Gatsby site.**
+### 1. **Create a Gatsby site.**
 
-Use the Gatsby CLI to create a new site, specifying this project
-
-```sh
-gatsby new project-name https://github.com/LekoArts/gatsby-starter-specimens
-```
-
-2. **Start developing.**
-
-Navigate into your new site's directory and start it up.
+Use `git` to clone the site and navigate into it:
 
 ```sh
+git clone https://github.com/LekoArts/gatsby-starter-specimens project-name
 cd project-name
-gatsby develop
 ```
 
-3. **Open the code and start customizing!**
+### 2. **Install dependencies.**
+
+If you use npm 7 or above use the `--legacy-peer-deps` flag. If you use npm 6 you can use `npm install`.
+
+```sh
+npm install --legacy-peer-deps
+```
+
+### 3. **Open the code and start customizing!**
+
+Start the site by running `npm run develop`.
 
 Your site is now running at `http://localhost:8000`!
 

--- a/examples/specimens/gatsby-config.js
+++ b/examples/specimens/gatsby-config.js
@@ -10,9 +10,6 @@ module.exports = {
     banner: `https://specimens.lekoarts.de/banner.jpg`,
     siteUrl: `https://specimens.lekoarts.de`,
   },
-  flags: {
-    FAST_DEV: true,
-  },
   plugins: [
     {
       resolve: `@lekoarts/gatsby-theme-specimens`,

--- a/examples/status-dashboard/README.md
+++ b/examples/status-dashboard/README.md
@@ -32,24 +32,26 @@ Also be sure to check out other [Free & Open Source Gatsby Themes](https://theme
 
 [<img src="https://www.gatsbyjs.com/deploynow.svg" alt="Deploy to Gatsby Cloud">](https://www.gatsbyjs.com/dashboard/deploynow?url=https://github.com/LekoArts/gatsby-status-dashboard)
 
-1. **Create a Gatsby site.**
+### 1. **Create a Gatsby site.**
 
-Use the Gatsby CLI to create a new site, specifying this project
-
-```sh
-gatsby new project-name https://github.com/LekoArts/gatsby-status-dashboard
-```
-
-2. **Start developing.**
-
-Navigate into your new site's directory and start it up.
+Use `git` to clone the site and navigate into it:
 
 ```sh
+git clone https://github.com/LekoArts/gatsby-status-dashboard project-name
 cd project-name
-gatsby develop
 ```
 
-3. **Open the code and start customizing!**
+### 2. **Install dependencies.**
+
+If you use npm 7 or above use the `--legacy-peer-deps` flag. If you use npm 6 you can use `npm install`.
+
+```sh
+npm install --legacy-peer-deps
+```
+
+### 3. **Open the code and start customizing!**
+
+Start the site by running `npm run develop`.
 
 Your site is now running at `http://localhost:8000`!
 

--- a/examples/status-dashboard/gatsby-config.js
+++ b/examples/status-dashboard/gatsby-config.js
@@ -8,9 +8,6 @@ module.exports = {
     siteName: process.env.SITE_TITLE || `Status Dashboard - LekoArts`,
     siteDescription: process.env.SITE_DESCRIPTION || `Showing the statuses of my Netlify deploys & CircleCI tests.`,
   },
-  flags: {
-    FAST_DEV: true,
-  },
   plugins: [
     // See the theme's README for all available components
     `@lekoarts/gatsby-theme-status-dashboard`,

--- a/examples/styleguide/README.md
+++ b/examples/styleguide/README.md
@@ -38,24 +38,26 @@ Also be sure to check out other [Free & Open Source Gatsby Themes](https://theme
 
 [<img src="https://www.gatsbyjs.com/deploynow.svg" alt="Deploy to Gatsby Cloud">](https://www.gatsbyjs.com/dashboard/deploynow?url=https://github.com/LekoArts/gatsby-starter-styleguide)
 
-1. **Create a Gatsby site.**
+### 1. **Create a Gatsby site.**
 
-Use the Gatsby CLI to create a new site, specifying this project
-
-```sh
-gatsby new project-name https://github.com/LekoArts/gatsby-starter-styleguide
-```
-
-2. **Start developing.**
-
-Navigate into your new site's directory and start it up.
+Use `git` to clone the site and navigate into it:
 
 ```sh
+git clone https://github.com/LekoArts/gatsby-starter-styleguide project-name
 cd project-name
-gatsby develop
 ```
 
-3. **Open the code and start customizing!**
+### 2. **Install dependencies.**
+
+If you use npm 7 or above use the `--legacy-peer-deps` flag. If you use npm 6 you can use `npm install`.
+
+```sh
+npm install --legacy-peer-deps
+```
+
+### 3. **Open the code and start customizing!**
+
+Start the site by running `npm run develop`.
 
 Your site is now running at `http://localhost:8000`!
 

--- a/examples/styleguide/gatsby-config.js
+++ b/examples/styleguide/gatsby-config.js
@@ -13,9 +13,6 @@ module.exports = {
     siteImage: `/banner.jpg`,
     author: `@lekoarts_de`,
   },
-  flags: {
-    FAST_DEV: true,
-  },
   plugins: [
     `gatsby-plugin-theme-ui`,
     {


### PR DESCRIPTION
Don't use Gatsby CLI but normal `git clone` and `npm install` to show the `--legacy-peer-deps` flag.