### PR TITLE
Add missing gatsby-source-filesystem plugin to gatsby-config cara exa…

### DIFF
--- a/examples/cara/gatsby-config.js
+++ b/examples/cara/gatsby-config.js
@@ -12,6 +12,13 @@ module.exports = {
   },
   plugins: [
     {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        name: `pages`,
+        path: `${__dirname}/src/@lekoarts/gatsby-theme-cara/sections/`,
+      },
+    },
+    {
       resolve: `@lekoarts/gatsby-theme-cara`,
       // See the theme's README for all available options
       options: {},


### PR DESCRIPTION
Add missing gatsby-source-filesystem plugin to gatsby-config cara example

Closes https://github.com/LekoArts/gatsby-themes/issues/677