### PR TITLE
fix(gatsby-theme-minimal-blog): Incorrect link styling in bottom section

### DIFF
--- a/.changeset/swift-plants-greet.md
+++ b/.changeset/swift-plants-greet.md
@@ -1,0 +1,7 @@
+---
+"@lekoarts/gatsby-theme-minimal-blog": patch
+---
+
+fix(gatsby-theme-minimal-blog): Incorrect link styling in bottom section
+
+Links were rendered at a bigger size in the `<Bottom />` section. The styles were changed to only apply this bigger `fontSize` for links inside `<li>` items.

--- a/themes/gatsby-theme-minimal-blog/src/components/homepage.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/homepage.tsx
@@ -44,7 +44,7 @@ const Homepage = ({ posts }: PostsProps) => {
         <Link to={replaceSlashes(`/${basePath}/${blogPath}`)}>Read all posts</Link>
       </Title>
       <Listing posts={posts} showTags={false} />
-      <List sx={{ variant: `section_bottom` }}>
+      <List>
         <Bottom />
       </List>
     </Layout>

--- a/themes/gatsby-theme-minimal-blog/src/components/list.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/list.tsx
@@ -11,8 +11,8 @@ const List = ({ children }: ListProps) => (
     sx={{
       mb: [5, 5, 6],
       ul: { margin: 0, padding: 0 },
-      li: { listStyle: `none`, mb: 3 },
-      a: { variant: `links.listItem` },
+      li: { listStyle: `none`, mb: 3, a: { variant: `links.listItem` } },
+      variant: `section_bottom`,
     }}
   >
     {children}


### PR DESCRIPTION
Fixes https://github.com/LekoArts/gatsby-themes/issues/726