### PR TITLE
fix(gatsby-theme-minimal-blog): Use main landmark

### DIFF
--- a/.changeset/witty-peaches-clap.md
+++ b/.changeset/witty-peaches-clap.md
@@ -1,0 +1,5 @@
+---
+"@lekoarts/gatsby-theme-minimal-blog": patch
+---
+
+Add main landmark to layout component

--- a/themes/gatsby-theme-minimal-blog/src/components/layout.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/layout.tsx
@@ -44,7 +44,7 @@ const Layout = ({ children, className = `` }: LayoutProps) => (
     <SkipNavLink>Skip to content</SkipNavLink>
     <Container>
       <Header />
-      <Box id="skip-nav" sx={{ ...CodeStyles }} className={className}>
+      <Box id="skip-nav" as="main" role="main" sx={{ ...CodeStyles }} className={className}>
         {children}
       </Box>
       <Footer />

--- a/themes/gatsby-theme-minimal-blog/src/components/layout.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/layout.tsx
@@ -44,7 +44,7 @@ const Layout = ({ children, className = `` }: LayoutProps) => (
     <SkipNavLink>Skip to content</SkipNavLink>
     <Container>
       <Header />
-      <Box id="skip-nav" as="main" role="main" sx={{ ...CodeStyles }} className={className}>
+      <Box id="skip-nav" as="main" variant="layout.main" sx={{ ...CodeStyles }} className={className}>
         {children}
       </Box>
       <Footer />


### PR DESCRIPTION
This change allows the theme to pass axe-core's rules:
- https://dequeuniversity.com/rules/axe/4.3/landmark-one-main?application=axeAPI
- https://dequeuniversity.com/rules/axe/4.3/region?application=axeAPI

There was already a `<header>` and `<footer>` but no `<main>`.