### PR TITLE
chore: Update peerDependencies to include React 18

### DIFF
--- a/.changeset/real-bears-allow.md
+++ b/.changeset/real-bears-allow.md
@@ -1,0 +1,17 @@
+---
+"@lekoarts/gatsby-theme-cara": patch
+"@lekoarts/gatsby-theme-emilia": patch
+"@lekoarts/gatsby-theme-emilia-core": patch
+"@lekoarts/gatsby-theme-emma": patch
+"@lekoarts/gatsby-theme-emma-core": patch
+"@lekoarts/gatsby-theme-graphql-playground": patch
+"@lekoarts/gatsby-theme-jodie": patch
+"@lekoarts/gatsby-theme-jodie-core": patch
+"@lekoarts/gatsby-theme-minimal-blog": patch
+"@lekoarts/gatsby-theme-minimal-blog-core": patch
+"@lekoarts/gatsby-theme-specimens": patch
+"@lekoarts/gatsby-theme-status-dashboard": patch
+"@lekoarts/gatsby-theme-styleguide": patch
+---
+
+chore: Update peerDependencies to include React 18

--- a/themes/gatsby-theme-cara/package.json
+++ b/themes/gatsby-theme-cara/package.json
@@ -16,8 +16,8 @@
   },
   "peerDependencies": {
     "gatsby": "^4.0.0",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   },
   "dependencies": {
     "@mdx-js/mdx": "^1.6.22",

--- a/themes/gatsby-theme-emilia-core/package.json
+++ b/themes/gatsby-theme-emilia-core/package.json
@@ -16,8 +16,8 @@
   },
   "peerDependencies": {
     "gatsby": "^4.0.0",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   },
   "dependencies": {
     "@mdx-js/mdx": "^1.6.22",

--- a/themes/gatsby-theme-emilia/package.json
+++ b/themes/gatsby-theme-emilia/package.json
@@ -16,8 +16,8 @@
   },
   "peerDependencies": {
     "gatsby": "^4.0.0",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   },
   "dependencies": {
     "@lekoarts/gatsby-theme-emilia-core": "^3.0.6",

--- a/themes/gatsby-theme-emma-core/package.json
+++ b/themes/gatsby-theme-emma-core/package.json
@@ -16,8 +16,8 @@
   },
   "peerDependencies": {
     "gatsby": "^4.0.0",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   },
   "dependencies": {
     "@mdx-js/mdx": "^1.6.22",

--- a/themes/gatsby-theme-emma/package.json
+++ b/themes/gatsby-theme-emma/package.json
@@ -16,8 +16,8 @@
   },
   "peerDependencies": {
     "gatsby": "^4.0.0",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   },
   "dependencies": {
     "@lekoarts/gatsby-theme-emma-core": "^3.0.6",

--- a/themes/gatsby-theme-graphql-playground/package.json
+++ b/themes/gatsby-theme-graphql-playground/package.json
@@ -16,8 +16,8 @@
   },
   "peerDependencies": {
     "gatsby": "^4.0.0",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   },
   "dependencies": {
     "@mdx-js/mdx": "^1.6.22",

--- a/themes/gatsby-theme-jodie-core/package.json
+++ b/themes/gatsby-theme-jodie-core/package.json
@@ -16,8 +16,8 @@
   },
   "peerDependencies": {
     "gatsby": "^4.0.0",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   },
   "dependencies": {
     "@mdx-js/mdx": "^1.6.22",

--- a/themes/gatsby-theme-jodie/package.json
+++ b/themes/gatsby-theme-jodie/package.json
@@ -16,8 +16,8 @@
   },
   "peerDependencies": {
     "gatsby": "^4.0.0",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   },
   "dependencies": {
     "@lekoarts/gatsby-theme-jodie-core": "^3.0.4",

--- a/themes/gatsby-theme-minimal-blog-core/package.json
+++ b/themes/gatsby-theme-minimal-blog-core/package.json
@@ -16,8 +16,8 @@
   },
   "peerDependencies": {
     "gatsby": "^4.0.0",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   },
   "dependencies": {
     "@mdx-js/mdx": "^1.6.22",

--- a/themes/gatsby-theme-minimal-blog/package.json
+++ b/themes/gatsby-theme-minimal-blog/package.json
@@ -16,8 +16,8 @@
   },
   "peerDependencies": {
     "gatsby": "^4.0.0",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   },
   "dependencies": {
     "@lekoarts/gatsby-theme-minimal-blog-core": "^4.1.4",

--- a/themes/gatsby-theme-specimens/package.json
+++ b/themes/gatsby-theme-specimens/package.json
@@ -17,8 +17,8 @@
   },
   "peerDependencies": {
     "gatsby": "^4.0.0",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1",
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0",
     "theme-ui": ">=0.11"
   },
   "dependencies": {

--- a/themes/gatsby-theme-status-dashboard/package.json
+++ b/themes/gatsby-theme-status-dashboard/package.json
@@ -16,8 +16,8 @@
   },
   "peerDependencies": {
     "gatsby": "^4.0.0",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   },
   "dependencies": {
     "@theme-ui/presets": "^0.11.1",

--- a/themes/gatsby-theme-styleguide/package.json
+++ b/themes/gatsby-theme-styleguide/package.json
@@ -16,8 +16,8 @@
   },
   "peerDependencies": {
     "gatsby": "^4.0.0",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1",
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0",
     "theme-ui": ">=0.11"
   },
   "dependencies": {


### PR DESCRIPTION
The themes also support React 18, so updated the peerDependencies.