### PR TITLE
fix(gatsby-theme-emilia): Text Align on Cards

### DIFF
--- a/.changeset/sixty-glasses-stare.md
+++ b/.changeset/sixty-glasses-stare.md
@@ -1,0 +1,5 @@
+---
+"@lekoarts/gatsby-theme-emilia": patch
+---
+
+Align text on card in center

--- a/.changeset/sixty-glasses-stare.md
+++ b/.changeset/sixty-glasses-stare.md
@@ -2,4 +2,4 @@
 "@lekoarts/gatsby-theme-emilia": patch
 ---
 
-Align text on card in center
+Set `text-align: center` on text in cards

--- a/themes/gatsby-theme-emilia/src/components/card.tsx
+++ b/themes/gatsby-theme-emilia/src/components/card.tsx
@@ -59,7 +59,10 @@ const Card = ({ item, overlay = `#000`, shadow = shadowArray, eager }: CardProps
       }}
       data-name="card-overlay"
     >
-      <Heading variant="styles.h2" sx={{ my: 0, textShadow: `rgba(0, 0, 0, 0.2) 0px 2px 12px`, color: `white` }}>
+      <Heading
+        variant="styles.h2"
+        sx={{ my: 0, textShadow: `rgba(0, 0, 0, 0.2) 0px 2px 12px`, color: `white`, textAlign: `center` }}
+      >
         {item.title}
       </Heading>
     </div>


### PR DESCRIPTION
Fixes https://github.com/LekoArts/gatsby-themes/issues/983