### PR TITLE
fix(themes-utils): Change early check in preToCodeBlock

### DIFF
--- a/.changeset/slow-panthers-taste.md
+++ b/.changeset/slow-panthers-taste.md
@@ -1,0 +1,5 @@
+---
+"@lekoarts/themes-utils": patch
+---
+
+Fix a subtle bug in `preToCodeBlock`. The `preToCodeBlock` was checking for a `type` that could never occur. So the syntax highlighting was broken for sites using `preToCodeBlock`. The check was changed now to see if `preProps?.children?.props` exists.

--- a/packages/themes-utils/src/__tests__/index.ts
+++ b/packages/themes-utils/src/__tests__/index.ts
@@ -8,7 +8,6 @@ const preProps = {
       className: `language-javascript` as GetLanguageInput,
       otherProps: `Hello World`,
     },
-    type: `code`,
   },
 }
 
@@ -56,9 +55,7 @@ describe(`preToCodeBlock`, () => {
     })
   })
   it(`handles minimal shape`, () => {
-    expect(
-      preToCodeBlock({ children: { props: { children: `This is the code string` }, type: `code` } })
-    ).toStrictEqual({
+    expect(preToCodeBlock({ children: { props: { children: `This is the code string` } } })).toStrictEqual({
       className: ``,
       codeString: preProps.children.props.children,
       language: ``,

--- a/packages/themes-utils/src/index.ts
+++ b/packages/themes-utils/src/index.ts
@@ -45,15 +45,14 @@ interface IPreProps {
       withLineNumbers?: boolean
       [key: string]: any
     }
-    type: string
   }
 }
 
 const preToCodeBlock = (preProps: IPreProps) => {
-  if (preProps?.children?.type === `code`) {
+  if (preProps?.children?.props) {
     const { children: codeString, className = ``, ...props } = preProps.children.props
-
     const match = className.match(/language-([\0-\uFFFF]*)/)
+
     return {
       codeString: codeString.trim(),
       className: className as GetLanguageInput,


### PR DESCRIPTION
Fixes https://github.com/LekoArts/gatsby-themes/issues/1017