### PR TITLE
feat(gatsby-theme-minimal-blog): Add table of content to post page.

### DIFF
--- a/themes/gatsby-theme-minimal-blog-core/gatsby-config.js
+++ b/themes/gatsby-theme-minimal-blog-core/gatsby-config.js
@@ -46,6 +46,7 @@ module.exports = (themeOptions) => {
                 backgroundColor: `transparent`,
               },
             },
+            `gatsby-remark-autolink-headers`,
           ],
         },
       },

--- a/themes/gatsby-theme-minimal-blog-core/package.json
+++ b/themes/gatsby-theme-minimal-blog-core/package.json
@@ -25,6 +25,7 @@
     "@mdx-js/react": "^2.2.1",
     "gatsby-plugin-mdx": "^5.3.1",
     "gatsby-plugin-sharp": "^5.3.2",
+    "gatsby-remark-autolink-headers": "^6.4.0",
     "gatsby-remark-images": "^7.3.1",
     "gatsby-source-filesystem": "^5.3.1",
     "gatsby-transformer-sharp": "^5.3.1",

--- a/themes/gatsby-theme-minimal-blog/package.json
+++ b/themes/gatsby-theme-minimal-blog/package.json
@@ -30,7 +30,8 @@
     "gatsby-plugin-catch-links": "^5.3.0",
     "gatsby-plugin-theme-ui": "~0.15.3",
     "prism-react-renderer": "^1.3.5",
-    "theme-ui": "~0.15.3"
+    "theme-ui": "~0.15.3",
+    "tocbot": "^4.20.0"
   },
   "keywords": [
     "gatsby",

--- a/themes/gatsby-theme-minimal-blog/src/components/post.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/post.tsx
@@ -6,6 +6,7 @@ import Layout from "./layout"
 import ItemTags from "./item-tags"
 import Seo from "./seo"
 import PostFooter from "./post-footer"
+import Tocbot from "./toc"
 
 export type MBPostProps = {
   post: {
@@ -49,7 +50,8 @@ const Post: React.FC<React.PropsWithChildren<PageProps<MBPostProps>>> = ({ data:
       {post.timeToRead && ` — `}
       {post.timeToRead && <span>{post.timeToRead} min read</span>}
     </p>
-    <section
+    <Tocbot />
+    <section className="js-toc-content"
       sx={{
         my: 5,
         ".gatsby-resp-image-wrapper": {

--- a/themes/gatsby-theme-minimal-blog/src/components/toc.tsx
+++ b/themes/gatsby-theme-minimal-blog/src/components/toc.tsx
@@ -1,0 +1,44 @@
+/** @jsx jsx */
+import { jsx } from "theme-ui"
+import * as React from "react"
+import tocbot from "tocbot"
+import "tocbot/static/css/tocbot.css"
+
+const Tocbot = () => {
+    React.useLayoutEffect(() => {
+        tocbot.init({
+            tocSelector: ".js-toc",
+            contentSelector: ".js-toc-content",
+            headingSelector: "h2, h3, h4",
+            hasInnerContainers: true,
+            collapseDepth: 4,
+            scrollSmooth: false,
+        });
+        return () => {
+            tocbot.destroy();
+        }
+    });
+
+    return (
+        <nav className="toc js-toc"
+            sx={{
+                transform: [null, null, null, null, null, "translateX(100%)"],
+                right: ["0", "0", "0", "0", "0", "calc((100% - 64rem) / 2)"],
+                height: "100%",
+                width: [null, null, null, null, null, "16rem"],
+                p: "1rem",
+                pt: "10rem",
+                pb: "5rem",
+                position: "fixed",
+                top: "0",
+                display: ["none", "none", "none", "none", "none", "initial"],
+                ".toc-link": {
+                    textDecoration: "none",
+                },
+            }}
+        >
+        </nav>
+    )
+}
+
+export default Tocbot

--- a/themes/gatsby-theme-minimal-blog/src/gatsby-plugin-theme-ui/index.js
+++ b/themes/gatsby-theme-minimal-blog/src/gatsby-plugin-theme-ui/index.js
@@ -6,6 +6,7 @@ const theme = merge(tailwind, {
   config: {
     initialColorModeName: `light`,
   },
+  breakpoints: [`640px`, `768px`, `1024px`, `1280px`, `1536px`],
   colors: {
     primary: tailwind.colors.purple[7],
     secondary: `#5f6c80`,


### PR DESCRIPTION
When the width of the window is appropriate ( >=1536px ), display the table of content.

![image](https://user-images.githubusercontent.com/1856880/213399023-e9b34590-7ac4-41bd-b058-9fb679642f15.png)
