### PR TITLE
feat(gatsby-theme-minimal-blog-core): Make number of latest posts on homepage configurable

### DIFF
--- a/themes/gatsby-theme-minimal-blog-core/README.md
+++ b/themes/gatsby-theme-minimal-blog-core/README.md
@@ -53,6 +53,7 @@ npm install @lekoarts/gatsby-theme-minimal-blog-core
 | `mdx`          | `true`          | Configure `gatsby-plugin-mdx` (if your website already is using the plugin pass `false` to turn this off)   |
 | `sharp`        | `true`          | Configure `gatsby-plugin-sharp` (if your website already is using the plugin pass `false` to turn this off) |
 | `formatString` | `DD.MM.YYYY`    | Configure the date format for Date fields                                                                   |
+| `maxLatestPostsOnHomepage` | `3`    | Configure the maximum number of posts to show under "Latest Posts" on home page. |
 
 The usage of `content/pages` is optional.
 

--- a/themes/gatsby-theme-minimal-blog-core/gatsby-node.js
+++ b/themes/gatsby-theme-minimal-blog-core/gatsby-node.js
@@ -285,13 +285,14 @@ const tagsTemplate = require.resolve(`./src/templates/tags-query.tsx`)
 exports.createPages = async ({ actions, graphql, reporter }, themeOptions) => {
   const { createPage } = actions
 
-  const { basePath, blogPath, tagsPath, formatString } = withDefaults(themeOptions)
+  const { basePath, blogPath, tagsPath, formatString, maxLatestPostsOnHomepage } = withDefaults(themeOptions)
 
   createPage({
     path: basePath,
     component: homepageTemplate,
     context: {
       formatString,
+      maxLatestPostsOnHomepage,
     },
   })
 

--- a/themes/gatsby-theme-minimal-blog-core/src/templates/homepage-query.tsx
+++ b/themes/gatsby-theme-minimal-blog-core/src/templates/homepage-query.tsx
@@ -6,8 +6,8 @@ export default HomepageComponent
 export { Head }
 
 export const query = graphql`
-  query ($formatString: String!) {
-    allPost(sort: { date: DESC }, limit: 3) {
+  query ($formatString: String!, $maxLatestPostsOnHomepage: Int) {
+    allPost(sort: { date: DESC }, limit: $maxLatestPostsOnHomepage) {
       nodes {
         slug
         title


### PR DESCRIPTION
`gatsby-theme-minimal-blog` only shows up to three latest posts on homepage by default. I would like it to show more.

This PR adds a `maxLatestPostsOnHomepage` theme option to override it.