### PR TITLE
fix(gatsby-theme-jodie): Correct CSS for `<img>` on custom pages

### DIFF
--- a/.changeset/serious-shirts-protect.md
+++ b/.changeset/serious-shirts-protect.md
@@ -1,0 +1,5 @@
+---
+"@lekoarts/gatsby-theme-jodie": patch
+---
+
+fix(gatsby-theme-jodie): Correct CSS for <img> on custom pages

--- a/themes/gatsby-theme-jodie/src/gatsby-plugin-theme-ui/index.ts
+++ b/themes/gatsby-theme-jodie/src/gatsby-plugin-theme-ui/index.ts
@@ -43,6 +43,9 @@ const theme = merge(tailwind, {
     custom: {
       margin: 0,
       padding: 0,
+      img: {
+        maxWidth: `100%`,
+      },
     },
     project: {
       ...contentStyles,


### PR DESCRIPTION
Use `img { max-width: "100%" }` on custom pages

Fixes https://github.com/LekoArts/gatsby-themes/issues/1153