### PR TITLE
fix(jodie-core): Allow `0` for `homepagePageLimit` and `homepageProjectLimit`

### DIFF
--- a/.changeset/short-pans-guess.md
+++ b/.changeset/short-pans-guess.md
@@ -1,0 +1,5 @@
+---
+"@lekoarts/gatsby-theme-jodie-core": patch
+---
+
+Allow `0` for `homepagePageLimit` and `homepageProjectLimit` theme options. Previously that value would have no effect and the default value was used.

--- a/themes/gatsby-theme-jodie-core/utils/default-options.mjs
+++ b/themes/gatsby-theme-jodie-core/utils/default-options.mjs
@@ -6,8 +6,8 @@ export const withDefaults = (themeOptions) => {
   const pagesPath = themeOptions.pagesPath || `content/pages`
   const formatString = themeOptions.formatString || `DD.MM.YYYY`
   const navigation = themeOptions.navigation || []
-  const homepagePageLimit = themeOptions.homepagePageLimit || 9999
-  const homepageProjectLimit = themeOptions.homepageProjectLimit || 3
+  const homepagePageLimit = themeOptions.homepagePageLimit ?? 9999
+  const homepageProjectLimit = themeOptions.homepageProjectLimit ?? 3
   const mdx = typeof themeOptions.mdx === `undefined` ? true : themeOptions.mdx
   const sharp = typeof themeOptions.sharp === `undefined` ? true : themeOptions.sharp
 


### PR DESCRIPTION
Replacing logical or with the nullish coalescing operator allows 0 to be picked from the themeOptions, and wont be overridden by the provided default.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing