### PR TITLE
Copy linked files if they are not supported by transformer-sharp

### DIFF
--- a/themes/gatsby-theme-minimal-blog-core/gatsby-config.mjs
+++ b/themes/gatsby-theme-minimal-blog-core/gatsby-config.mjs
@@ -46,6 +46,10 @@ const config = (themeOptions) => {
                 backgroundColor: `transparent`,
               },
             },
+            {
+              resolve: `gatsby-remark-copy-linked-files`,
+              options: { destinationDir: `static`, },
+            },
           ],
         },
       },

--- a/themes/gatsby-theme-minimal-blog-core/package.json
+++ b/themes/gatsby-theme-minimal-blog-core/package.json
@@ -26,6 +26,7 @@
     "gatsby-plugin-mdx": "^5.13.1",
     "gatsby-plugin-sharp": "^5.13.1",
     "gatsby-remark-images": "^7.13.1",
+    "gatsby-remark-copy-linked-files": "^6.13.1",
     "gatsby-source-filesystem": "^5.13.1",
     "gatsby-transformer-sharp": "^5.13.1",
     "reading-time": "^1.5.0",


### PR DESCRIPTION
Thanks for providing great starter theme.  Unfortunately,  there is a small problem with the minimal-blog-core theme.  It doesn't support animated gifs.

The post below explains the root cause of the issue

https://www.reddit.com/r/gatsbyjs/comments/hrs7tj/gatsby_not_rendering_gifs_in_markdown_files/

This Gatsby issue explains how to fix it

https://github.com/gatsbyjs/gatsby/issues/7317

And this PR provides the fix.  Because Gatsby theme shadowing does not extend to the config files the core theme has to be patched to provide the fix.

